### PR TITLE
Collapse non active nav item menu groups by default

### DIFF
--- a/src/components/DashboardLayout/NavItem.jsx
+++ b/src/components/DashboardLayout/NavItem.jsx
@@ -100,8 +100,16 @@ const NavItem = (props) => {
     isExpandible = false,
     disableHoverEffect = false,
     hoverMenuItem = false,
+    defaultExpanded = false,
   } = props;
-  const [expanded, setExpanded] = useState(true);
+  
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  useEffect(() => {
+    if (defaultExpanded) {
+      setExpanded(true);
+    }
+  }, [defaultExpanded]);
 
   function handleExpandToggle() {
     if (isExpandible) {

--- a/src/components/MarketplaceServiceSidebar/MarketplaceServiceSidebar.jsx
+++ b/src/components/MarketplaceServiceSidebar/MarketplaceServiceSidebar.jsx
@@ -194,6 +194,8 @@ function MarketplaceServiceSidebar(props) {
       IconComponent: ShieldIcon,
       isActive: false,
       isExpandible: true,
+      defaultExpanded:
+        isAccessControlActive || isAuditLogsActive || isNotificationsActive,
       subItems: [
         {
           name: "Access Control",
@@ -221,6 +223,8 @@ function MarketplaceServiceSidebar(props) {
       IconComponent: AccountManagementIcon,
       isActive: false,
       isExpandible: true,
+      defaultExpanded:
+        isSettingsActive || isBillingActive || isSubscriptionsActive,
       subItems: [
         {
           name: "Settings",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `defaultExpanded` prop to the `NavItem` component for enhanced control over its initial expanded state.
	- Added dynamic expansion control for "Security Controls" and "Account Management" sections in the `MarketplaceServiceSidebar`, based on active states of related items.

- **Bug Fixes**
	- Improved logic for determining the expansion state of sidebar items to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->