### PR TITLE
Fix time picker aria

### DIFF
--- a/src/components/ResourceInstance/Backup/components/BackupTableHeader.tsx
+++ b/src/components/ResourceInstance/Backup/components/BackupTableHeader.tsx
@@ -47,7 +47,7 @@ const BackupsTableHeader: FC<BackupsTableHeaderProps> = ({
         borderBottom="1px solid #EAECF0"
       >
         <DataGridHeaderTitle
-          title={`List of Completed backups ${resourceName ? `for ${resourceName}` : ""}`}
+          title={`List of completed backups ${resourceName ? `for ${resourceName}` : ""}`}
           desc="View and manage your backups"
           count={count}
           units={{

--- a/src/components/TimePickerSlider/TimePickerSlider.tsx
+++ b/src/components/TimePickerSlider/TimePickerSlider.tsx
@@ -336,9 +336,6 @@ const TimePickerSlider: React.FC<TimePickerSliderProps> = (props) => {
       <Box flexBasis={547} flexGrow={1} position="relative">
         <TimeSlider
           slots={{ thumb: TimeSliderThumbComponent }}
-          getAriaLabel={(index) =>
-            index === 0 ? "Minimum price" : "Maximum price"
-          }
           min={0}
           max={1439}
           marks={marks}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `getAriaLabel` prop from the `TimePickerSlider`, which may affect accessibility for screen reader users.

- **Improvements**
	- Updated the title in the `BackupsTableHeader` component from "Completed" to "completed" for consistency in display text. 

- **Chores**
	- Maintained the overall structure and functionality of the `TimePickerSlider` component without introducing new features or altering existing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->