### PR TITLE
Fix: Data Table Alignment

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -203,7 +203,7 @@ const DataTable = <TData,>(props: DataTableProps<TData>): ReactNode => {
                     {headerGroup.headers.map((header) => {
                       const sortDirection = header.column.getIsSorted();
                       const columnAlignment =
-                        header.column.columnDef.meta?.align || "center";
+                        header.column.columnDef.meta?.align || "left";
                       return (
                         <TableCell
                           align={columnAlignment}
@@ -257,7 +257,7 @@ const DataTable = <TData,>(props: DataTableProps<TData>): ReactNode => {
                         {row.getVisibleCells().map((cell) => {
                           const cellValue = cell.getValue();
                           const columnAlignment =
-                            cell.column.columnDef.meta?.align || "center";
+                            cell.column.columnDef.meta?.align || "left";
                           let title = "";
                           if (
                             ["string", "number", "boolean"].includes(

--- a/src/components/GridCellExpand/GridCellExpand.tsx
+++ b/src/components/GridCellExpand/GridCellExpand.tsx
@@ -38,7 +38,7 @@ const GridCellExpand = React.memo(function GridCellExpand(
     onClick = () => {},
     href,
     target = "_self",
-    justifyContent = "center",
+    justifyContent = "start",
     externalLinkArrow,
   } = props;
   const wrapper = React.useRef(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated default alignment of table cells in the DataTable component from center to left.
	- Changed default value of justifyContent in the GridCellExpand component from center to start.

- **Chores**
	- Minor adjustments to comments and formatting in both components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->