### PR TITLE
network type is fix

### DIFF
--- a/pages/access/service/[serviceId].js
+++ b/pages/access/service/[serviceId].js
@@ -754,7 +754,7 @@ function MarketplaceService() {
     initialValues: {
       serviceId: serviceId,
       cloud_provider: defaultCloudProvider,
-      network_type: "PUBLIC",
+      network_type: service?.supportsPublicNetwork ? "PUBLIC" : "INTERNAL",
       region: "",
       requestParams: { ...requestParams },
       serviceProviderId: service?.serviceProviderId,

--- a/src/components/Forms/CreateResourceInstanceForm.jsx
+++ b/src/components/Forms/CreateResourceInstanceForm.jsx
@@ -233,7 +233,9 @@ function CreateResourceInstanceForm(props) {
   const selectedCustomNetworkId = formData.values?.custom_network_id ?? "";
 
   const networkTypeFieldExists =
-    cloudProviderFieldExists && !isCustomNetworkEnabled;
+    cloudProviderFieldExists &&
+    !isCustomNetworkEnabled &&
+    service?.supportsPublicNetwork;
 
   if (isSchemaLoading)
     return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Network Type" field visibility in the resource creation form now depends on whether the selected service supports public networks.
- **Bug Fixes**
	- Adjusted default value logic for the `network_type` field to reflect service capabilities during resource instance creation.
- **Style**
	- Minor formatting adjustments made for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->