### PR TITLE
fix node status tootltip icon unhealth color 

### DIFF
--- a/src/components/ResourceInstance/NodesTable/NodeStatusTooltip.jsx
+++ b/src/components/ResourceInstance/NodesTable/NodeStatusTooltip.jsx
@@ -61,7 +61,7 @@ const NodeStatusTooltip = ({ detailedHealth, children }) => {
                 <CircleCheckIcon />
               ) : (
                 <CircleCrossIcon
-                  color={item.status === "UNHEALTHY" ? "" : "#808080"}
+                  color={item.status === "UNHEALTHY" ? "#F44336" : "#808080"}
                 />
               )}
               <Text size="xsmall" weight="regular" color="rgba(52, 64, 84, 1)">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated color of status indicator for "UNHEALTHY" nodes to red, improving visual clarity of node status in tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->