### PR TITLE
fix for complex resource not show for auto and backup

### DIFF
--- a/app/(dashboard)/instances/[serviceId]/[servicePlanId]/[resourceId]/[instanceId]/[subscriptionId]/page.tsx
+++ b/app/(dashboard)/instances/[serviceId]/[servicePlanId]/[resourceId]/[instanceId]/[subscriptionId]/page.tsx
@@ -307,6 +307,7 @@ const InstanceDetailsPage = ({
           backupStatus={resourceInstanceData.backupStatus}
           autoscaling={resourceInstanceData.autoscaling}
           serverlessEnabled={resourceInstanceData.serverlessEnabled}
+          isCliManagedResource={isCliManagedResource}
         />
       )}
       {currentTab === tabs.connectivity && (

--- a/src/components/ResourceInstance/ResourceInstanceDetails/ResourceInstanceDetails.jsx
+++ b/src/components/ResourceInstance/ResourceInstanceDetails/ResourceInstanceDetails.jsx
@@ -28,6 +28,7 @@ function ResourceInstanceDetails(props) {
     backupStatus,
     autoscaling,
     serverlessEnabled,
+    isCliManagedResource,
   } = props;
 
   const isResourceBYOA =
@@ -94,18 +95,21 @@ function ResourceInstanceDetails(props) {
         value: highAvailability ? "Enabled" : "Disabled",
         valueType: "boolean",
       },
-      {
-        label: "Backups",
-        value: backupStatus?.backupPeriodInHours ? "Enabled" : "Disabled",
-        valueType: "boolean",
-      },
-      {
-        label: "Autoscaling",
-        value: autoscalingEnabled ? "Enabled" : "Disabled",
-        valueType: "boolean",
-      },
     ];
-
+    if (!isCliManagedResource) {
+      res.push(
+        {
+          label: "Backups",
+          value: backupStatus?.backupPeriodInHours ? "Enabled" : "Disabled",
+          valueType: "boolean",
+        },
+        {
+          label: "Autoscaling",
+          value: autoscalingEnabled ? "Enabled" : "Disabled",
+          valueType: "boolean",
+        }
+      );
+    }
     return res;
   }, [
     resourceInstanceId,

--- a/src/components/ResourceInstance/ResourceInstanceDetails/ResourceInstanceDetails.jsx
+++ b/src/components/ResourceInstance/ResourceInstanceDetails/ResourceInstanceDetails.jsx
@@ -120,6 +120,7 @@ function ResourceInstanceDetails(props) {
     resultParameters,
     highAvailability,
     backupStatus,
+    isCliManagedResource
   ]);
 
   const backupData = useMemo(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The instance details view now tailors the displayed information based on the type of resource management. For resources managed via the CLI, sections like Backups and Autoscaling are hidden, streamlining the user interface to show only relevant details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->