### PR TITLE
Disable browser tooltip for instance load column

### DIFF
--- a/app/(dashboard)/instances/page.tsx
+++ b/app/(dashboard)/instances/page.tsx
@@ -313,6 +313,7 @@ const InstancesPage = () => {
           },
           meta: {
             minWidth: 120,
+            disableBrowserTooltip: true,
           },
         }
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated tooltip behavior on the Instances page. The load status column now omits the default browser tooltip for a cleaner, more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->