### PR TITLE
fix disabled subscription plan styles

### DIFF
--- a/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
+++ b/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
@@ -49,7 +49,7 @@ const SubscriptionPlanCard = ({
       className={clsx(
         "flex items-start justify-between gap-3 px-4 pt-4 pb-3 rounded-xl outline outline-[2px]",
         isSelected ? "outline-success-500" : "outline-gray-300",
-        (!subscriptions.length || disabled) && "bg-gray-50"
+        (!subscriptions.length || disabled || isPlanSelectionDisabled) && "bg-gray-50"
       )}
       style={{
         cursor:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the visual feedback for subscription plans by updating the background display to clearly indicate when a plan is not selectable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->