### PR TITLE
Show page spinner only on initial data load

### DIFF
--- a/app/(dashboard)/cost-explorer/page.tsx
+++ b/app/(dashboard)/cost-explorer/page.tsx
@@ -36,13 +36,20 @@ function CostExplorerPage() {
   const {
     data: usagePerDayData,
     isFetching: isFetchingUsagePerDay,
-    isLoading,
+    isLoading: isLoadingUsagePerDay,
   } = useConsumptionUsagePerDay({
     startDate: dateRange.startDate,
     endDate: filterEndDate,
     subscriptionID:
       selectedSubscriptionId.trim() !== "" ? selectedSubscriptionId : undefined,
   });
+
+  //show page spinner only on initial load
+  const isInitialLoad =
+    isLoadingUsagePerDay &&
+    !selectedSubscriptionId.trim() &&
+    dateRange.startDate === defaultDailyDateRange.startDate &&
+    dateRange.endDate === defaultDailyDateRange.endDate;
 
   return (
     <div>
@@ -54,7 +61,7 @@ function CostExplorerPage() {
         <PageTitle icon={CostExplorerIcon} className="mb-6">
           Cost Explorer
         </PageTitle>
-        {isLoading ? (
+        {isInitialLoad ? (
           <LoadingSpinner />
         ) : (
           <UsageOverview


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the loading indicator on the Cost Explorer dashboard to display only during the initial data load, providing a smoother and more intuitive experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->