### PR TITLE
Disable delete button if active instances

### DIFF
--- a/app/(dashboard)/instances/components/InstancesTableHeader.tsx
+++ b/app/(dashboard)/instances/components/InstancesTableHeader.tsx
@@ -139,6 +139,7 @@ const InstancesTableHeader = ({
       isDisabled:
         !selectedInstance ||
         status !== "RUNNING" ||
+        status === "DISCONNECTED" ||
         isComplexResource ||
         isProxyResource ||
         !isUpdateAllowedByRBAC,
@@ -153,11 +154,13 @@ const InstancesTableHeader = ({
         ? "Please select an instance"
         : status !== "RUNNING"
           ? "Instance must be running to stop it"
-          : isComplexResource || isProxyResource
-            ? "System manages instances cannot be stopped"
-            : !isUpdateAllowedByRBAC
-              ? "Unauthorized to stop instances"
-              : "",
+          : status === "DISCONNECTED"
+            ? "Instance is disconnected"
+            : isComplexResource || isProxyResource
+              ? "System manages instances cannot be stopped"
+              : !isUpdateAllowedByRBAC
+                ? "Unauthorized to stop instances"
+                : "",
     });
 
     actions.push({
@@ -168,6 +171,7 @@ const InstancesTableHeader = ({
       isDisabled:
         !selectedInstance ||
         status !== "STOPPED" ||
+        status === "DISCONNECTED" ||
         isComplexResource ||
         isProxyResource ||
         !isUpdateAllowedByRBAC,
@@ -182,11 +186,13 @@ const InstancesTableHeader = ({
         ? "Please select an instance"
         : status !== "STOPPED"
           ? "Instances must be stopped before starting"
-          : isComplexResource || isProxyResource
-            ? "System managed instances cannot be started"
-            : !isUpdateAllowedByRBAC
-              ? "Unauthorized to start instances"
-              : "",
+          : status === "DISCONNECTED"
+            ? "Instance is disconnected"
+            : isComplexResource || isProxyResource
+              ? "System managed instances cannot be started"
+              : !isUpdateAllowedByRBAC
+                ? "Unauthorized to start instances"
+                : "",
     });
 
     actions.push({
@@ -198,6 +204,7 @@ const InstancesTableHeader = ({
         (status !== "RUNNING" &&
           status !== "FAILED" &&
           status !== "COMPLETE") ||
+        status === "DISCONNECTED" ||
         isProxyResource ||
         !isUpdateAllowedByRBAC,
       onClick: () => {
@@ -210,11 +217,13 @@ const InstancesTableHeader = ({
         ? "Please select an instance"
         : status !== "RUNNING" && status !== "FAILED"
           ? "Instance must be running or failed to modify"
-          : isProxyResource
-            ? "System managed instances cannot be modified"
-            : !isUpdateAllowedByRBAC
-              ? "Unauthorized to modify instances"
-              : "",
+          : status === "DISCONNECTED"
+            ? "Instance is disconnected"
+            : isProxyResource
+              ? "System managed instances cannot be modified"
+              : !isUpdateAllowedByRBAC
+                ? "Unauthorized to modify instances"
+                : "",
     });
 
     actions.push({
@@ -238,7 +247,7 @@ const InstancesTableHeader = ({
         : status === "DELETING"
           ? "Instance deletion is already in progress"
           : status === "DISCONNECTED"
-            ? "Cloud account is disconnected"
+            ? "Instance is disconnected"
             : isProxyResource
               ? "System managed instances cannot be deleted"
               : !isDeleteAllowedByRBAC

--- a/app/(dashboard)/settings/components/DeleteAccount.tsx
+++ b/app/(dashboard)/settings/components/DeleteAccount.tsx
@@ -8,6 +8,9 @@ import { useMutation } from "@tanstack/react-query";
 import { deleteUser } from "src/api/users";
 import useLogout from "src/hooks/useLogout";
 import useSnackbar from "src/hooks/useSnackbar";
+import useInstances from "app/(dashboard)/instances/hooks/useInstances";
+import Tooltip from "src/components/Tooltip/Tooltip";
+import LoadingSpinner from "src/components/LoadingSpinner/LoadingSpinner";
 
 const List = styled("ul")({
   listStyleType: "disc",
@@ -28,6 +31,9 @@ function DeleteAccount() {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const { handleLogout } = useLogout();
   const snackbar = useSnackbar();
+
+  const { data: instances = [], isLoading: isLoadingInstances } =
+    useInstances();
 
   function handleDialogOpen() {
     setConfirmationDialogOpen(true);
@@ -52,6 +58,8 @@ function DeleteAccount() {
       },
     }
   );
+
+  if (isLoadingInstances) return <LoadingSpinner />;
 
   return (
     <>
@@ -103,13 +111,22 @@ function DeleteAccount() {
             </div>
           </div>
           <div className="ml-5 mr-5 p-5 border-t border-[#E9EAEB] flex justify-end gap-3">
-            <Button
-              bgColor="#D92D20"
-              variant="contained"
-              onClick={handleDialogOpen}
+            <Tooltip
+              isVisible={instances.length > 0}
+              placement="top"
+              title="Please delete all instances to continue with account deletion"
             >
-              Delete Account
-            </Button>
+              <span>
+                <Button
+                  bgColor="#D92D20"
+                  variant="contained"
+                  onClick={handleDialogOpen}
+                  disabled={instances.length > 0}
+                >
+                  Delete Account
+                </Button>
+              </span>
+            </Tooltip>
           </div>
         </div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading spinner while fetching instance data in the account deletion section.
  - The "Delete Account" button is now disabled if you have existing instances, with a tooltip explaining the requirement to delete all instances before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->