### PR TITLE
Change license expiry warning period to 5 days

### DIFF
--- a/src/components/InstanceLicenseStatusChip/InstanceLicenseStatusChip.tsx
+++ b/src/components/InstanceLicenseStatusChip/InstanceLicenseStatusChip.tsx
@@ -30,7 +30,7 @@ const InstanceLicenseStatusChip: FC<LicenseStatusChipProps> = ({
       </Stack>
     );
 
-  const numDaysBeforeExpirationWarning = 7;
+  const numDaysBeforeExpirationWarning = 5;
 
   let shouldShowExpirationWarning = false;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the license expiration warning to appear 5 days before expiration instead of 7 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->