### PR TITLE
value of the custom dns text record

### DIFF
--- a/src/components/ResourceInstance/Connectivity/CustomDNSDetails.tsx
+++ b/src/components/ResourceInstance/Connectivity/CustomDNSDetails.tsx
@@ -70,8 +70,8 @@ const CustomDNSDetails: React.FC<CustomDNSDetailsProps> = ({
   records.push({
     recordLabel: "TXT",
     domainValue: `verification-${domainName}`,
-    recordValue: `target-${domainName}=${resourceInstanceId}`,
-    recordValueDetails: `The TXT record is a name-value pair, where the name must start with the prefix "target-", and the value should be the Instance ID.`,
+    recordValue: `${resourceInstanceId}`,
+    recordValueDetails: `The TXT record value is the instance ID`,
   });
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the display of TXT DNS record details by showing only the instance ID as the record value, with updated explanatory text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->