### PR TITLE
feat: migrate auth to httpOnly cookies

### DIFF
--- a/app/(public)/(main-image)/signin/components/SignInForm.tsx
+++ b/app/(public)/(main-image)/signin/components/SignInForm.tsx
@@ -9,7 +9,6 @@ import Cookies from "js-cookie";
 import ReCAPTCHA from "react-google-recaptcha";
 
 import { customerUserSignin } from "src/api/customer-user";
-import axios from "src/axios";
 import { Text } from "src/components/Typography/Typography";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
 import useSnackbar from "src/hooks/useSnackbar";
@@ -65,34 +64,31 @@ const SignInForm: FC<SignInFormProps> = ({
     /*eslint-disable-next-line react-hooks/exhaustive-deps*/
   }, [redirect_reason]);
 
-  function handlePasswordSignInSuccess(jwtToken) {
-    if (jwtToken) {
-      Cookies.set("token", jwtToken, { sameSite: "Lax", secure: true });
+  function handlePasswordSignInSuccess() {
+    // httpOnly cookie is set server-side by /api/signin — set indicator for UI auth state
+    Cookies.set("omnistrate_logged_in", "true", { expires: 1, sameSite: "Lax", secure: true });
 
-      try {
-        localStorage.removeItem("loggedInUsingSSO");
-      } catch (error) {
-        console.warn("Failed to set SSO state:", error);
-      }
+    try {
+      localStorage.removeItem("loggedInUsingSSO");
+    } catch (error) {
+      console.warn("Failed to set SSO state:", error);
+    }
 
-      axios.defaults.headers["Authorization"] = "Bearer " + jwtToken;
-      const decodedDestination = decodeURIComponent(destination || "");
+    const decodedDestination = decodeURIComponent(destination || "");
 
-      // Redirect to the Destination URL
-      if (destination && checkRouteValidity(decodedDestination)) {
-        router.replace(decodedDestination, {}, { showProgressBar: true });
-      } else {
-        router.replace(getInstancesRoute(), {}, { showProgressBar: true });
-      }
+    // Redirect to the Destination URL
+    if (destination && checkRouteValidity(decodedDestination)) {
+      router.replace(decodedDestination, {}, { showProgressBar: true });
+    } else {
+      router.replace(getInstancesRoute(), {}, { showProgressBar: true });
     }
   }
 
   const passwordSignInMutation = useMutation({
     mutationFn: (payload) => {
-      delete axios.defaults.headers["Authorization"];
       return customerUserSignin(payload);
     },
-    onSuccess: (response) => {
+    onSuccess: () => {
       setLoginMethod({
         methodType: "Password",
       });
@@ -101,9 +97,7 @@ const SignInForm: FC<SignInFormProps> = ({
       /*eslint-disable-next-line no-use-before-define*/
       formik.setFieldTouched("password", false);
 
-      //@ts-ignore
-      const jwtToken = response?.data?.jwtToken;
-      handlePasswordSignInSuccess(jwtToken);
+      handlePasswordSignInSuccess();
     },
     onError: (error: any) => {
       if (error.response.data && error.response.data.message) {

--- a/app/(public)/idp-auth/page.tsx
+++ b/app/(public)/idp-auth/page.tsx
@@ -8,7 +8,6 @@ import { Buffer } from "buffer";
 import Cookies from "js-cookie";
 
 import { customerSignInWithIdentityProvider } from "src/api/customer-user";
-import axios from "src/axios";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
 import useSnackbar from "src/hooks/useSnackbar";
 import checkRouteValidity from "src/utils/route/checkRouteValidity";
@@ -29,30 +28,26 @@ const IDPAuthPage = () => {
     async (payload, destination) => {
       try {
         hasAttemptedSignIn.current = true;
-        const response = await customerSignInWithIdentityProvider(payload);
-        // @ts-ignore
-        const jwtToken = response.data.jwtToken;
+        await customerSignInWithIdentityProvider(payload);
         sessionStorage.removeItem("authState");
-        if (jwtToken) {
-          Cookies.set("token", jwtToken, { sameSite: "Lax", secure: true });
-          axios.defaults.headers["Authorization"] = "Bearer " + jwtToken;
 
-          try {
-            localStorage.setItem("loggedInUsingSSO", "true");
-          } catch (error) {
-            console.warn("Failed to set SSO state:", error);
-          }
-          const decodedDestination = decodeURIComponent(destination);
-          hasAttemptedSignIn.current = false;
+        // httpOnly cookie is set server-side by /api/sign-in-with-idp — set indicator for UI auth state
+        Cookies.set("omnistrate_logged_in", "true", { expires: 1, sameSite: "Lax", secure: true });
 
-          // Redirect to the Destination URL
-          // Use window.location for full page reload to ensure middleware runs with fresh cookies
-          // This prevents race conditions where middleware might execute with stale cookies
-          if (destination && checkRouteValidity(decodedDestination)) {
-            window.location.href = decodedDestination;
-          } else {
-            window.location.href = getInstancesRoute();
-          }
+        try {
+          localStorage.setItem("loggedInUsingSSO", "true");
+        } catch (error) {
+          console.warn("Failed to set SSO state:", error);
+        }
+        const decodedDestination = decodeURIComponent(destination);
+        hasAttemptedSignIn.current = false;
+
+        // Redirect to the Destination URL
+        // Use window.location for full page reload to ensure middleware runs with fresh cookies
+        if (destination && checkRouteValidity(decodedDestination)) {
+          window.location.href = decodedDestination;
+        } else {
+          window.location.href = getInstancesRoute();
         }
       } catch (error) {
         sessionStorage.removeItem("authState");

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -23,11 +23,12 @@ Browser ←──same-origin──→ Next.js Server ──cross-domain──→
 
 ### Cookie Summary
 
-Two cookies are used:
+Three cookies are used:
 
 | Cookie | Name | Type | Set By | Purpose |
 |--------|------|------|--------|---------|
 | Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | Next.js server | Holds the JWT. Set and read only by the server. |
+| Refresh token | `omnistrate_refresh_token` | httpOnly, Secure, SameSite=Lax | Next.js server | Holds the refresh token. Used to obtain a new JWT when the current one expires. |
 | Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | Browser (js-cookie) | Lets the UI know the user is authenticated. |
 
 ## How It Works
@@ -42,13 +43,17 @@ Browser                    Next.js Server              Backend API
   │  { email, password }        ├─ POST /customer-user-signin ──►│
   │                             │                          │
   │                             │◄── { jwtToken: "..." } ──┤
+  │                             │    Set-Cookie: refresh_token=...
   │                             │                          │
-  │                             │── (extracts jwtToken,    │
-  │                             │   sets httpOnly cookie)   │
+  │                             │── (extracts jwtToken +   │
+  │                             │   refresh token from     │
+  │                             │   backend response,      │
+  │                             │   sets httpOnly cookies)  │
   │                             │                          │
   │◄── 200 OK ─────────────────┤                          │
   │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
-  │    (no token in body)       │                          │
+  │    Set-Cookie: omnistrate_refresh_token=...; HttpOnly  │
+  │    (no tokens in body)      │                          │
   │                             │                          │
   ├─ Sets omnistrate_logged_in  │                          │
   │  indicator cookie (JS)      │                          │
@@ -56,9 +61,10 @@ Browser                    Next.js Server              Backend API
 ```
 
 1. The browser sends credentials to `/api/signin` (Next.js API route).
-2. The Next.js server calls the backend (cross-domain), receives the JWT in the response body.
+2. The Next.js server calls the backend (cross-domain), receives the JWT in the response body and potentially a refresh token via Set-Cookie headers.
 3. The **Next.js server** sets the JWT as an httpOnly cookie (`omnistrate_token`) on its response to the browser — the backend cannot set cookies on the customer's domain because it's a different origin. The token never appears in the response body sent to the browser.
-4. The client sets a regular `omnistrate_logged_in` indicator cookie for UI state (route guards, request gating).
+4. If the backend returns a refresh token, the server also stores it as `omnistrate_refresh_token` (httpOnly).
+5. The client sets a regular `omnistrate_logged_in` indicator cookie for UI state (route guards, request gating).
 
 The same flow applies to IDP (SSO) sign-in via `/api/sign-in-with-idp`.
 
@@ -108,8 +114,9 @@ Browser                    Next.js Server              Backend API
   │                             │                          │
   │◄── 200 OK ─────────────────┤                          │
   │    Set-Cookie: omnistrate_token=; Max-Age=0            │
+  │    Set-Cookie: omnistrate_refresh_token=; Max-Age=0    │
   │    (Next.js server clears   │                          │
-  │     the httpOnly cookie)    │                          │
+  │     both httpOnly cookies)  │                          │
   │                             │                          │
   ├─ Removes omnistrate_logged_in│                         │
   ├─ Broadcasts "logout" to     │                          │
@@ -118,7 +125,7 @@ Browser                    Next.js Server              Backend API
 ```
 
 1. The client calls `POST /api/logout`.
-2. The Next.js server reads the httpOnly cookie, calls the backend to invalidate the token, then clears the httpOnly cookie (sets `Max-Age=0`). The backend cannot clear the cookie because it's on a different domain — the Next.js server handles it.
+2. The Next.js server reads the httpOnly cookie, calls the backend to invalidate the token, then clears both httpOnly cookies (access + refresh, `Max-Age=0`). The backend cannot clear the cookies because it's on a different domain — the Next.js server handles it.
 3. The client removes the indicator cookie, clears local state, and redirects to `/signin`.
 
 ### Middleware (Route Protection)
@@ -130,14 +137,50 @@ The Next.js middleware (`proxy.js`) runs on every navigation request:
 3. Validates the token by calling `GET /user` on the backend.
 4. Redirects to `/signin` if the token is missing, expired, or invalid.
 
-### 401 Handling
+### 401 Handling & Silent Token Refresh
 
-When any API response returns 401:
+When any API response returns 401, the client attempts a silent token refresh before logging out:
 
-- The **openapi-fetch client** (`src/api/client.ts`) removes the `omnistrate_logged_in` indicator cookie, clears localStorage, and redirects to `/signin`.
-- The **Axios error handler** (`AxiosGlobalErrorHandler.tsx`) calls the logout handler which does the same.
+```
+Browser                    Next.js Server              Backend API
+  │                             │                     (different domain)
+  │                             │                          │
+  ├─ Request returns 401 ──────►│                          │
+  │                             │                          │
+  ├─ POST /api/refresh-token ──►│                          │
+  │  (httpOnly refresh cookie   │                          │
+  │   sent automatically)       │                          │
+  │                             ├─ Reads refresh token     │
+  │                             │  from httpOnly cookie     │
+  │                             │                          │
+  │                             ├─ POST /refresh-token ───►│
+  │                             │  Cookie: refresh_token=...│
+  │                             │                          │
+  │                             │◄── new JWT / Set-Cookie ─┤
+  │                             │                          │
+  │                             │── Sets new               │
+  │                             │   omnistrate_token cookie │
+  │                             │                          │
+  │◄── 200 OK ─────────────────┤                          │
+  │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
+  │                             │                          │
+  ├─ Retries original request   │                          │
+  │  (new httpOnly cookie       │                          │
+  │   sent automatically)       │                          │
+```
 
-The httpOnly cookie is left as-is on 401 — it will be overwritten on the next sign-in or cleared by the middleware redirect.
+**Refresh flow (both openapi-fetch client and Axios):**
+
+1. On 401, the client calls `POST /api/refresh-token` (same-origin, httpOnly cookies included).
+2. The Next.js server reads the `omnistrate_refresh_token` httpOnly cookie.
+3. The server forwards it to the backend's `/refresh-token` endpoint.
+4. If the backend returns a new JWT (in body or Set-Cookie), the server stores it as the new `omnistrate_token` httpOnly cookie.
+5. The client retries the original request — the new cookie is sent automatically.
+6. If refresh fails, the user is logged out and redirected to `/signin`.
+
+**Coalescing:** Multiple concurrent 401s share a single refresh request to avoid hammering the endpoint.
+
+**Graceful degradation:** If the backend doesn't issue a refresh token on signin, the refresh attempt simply fails and the user is redirected to sign in — same as the previous behavior.
 
 ## Why This Architecture Works for Customer-Hosted Domains
 
@@ -169,6 +212,15 @@ Customer domain: portal.acme.com
   maxAge: 86400,       // 1 day — matches backend token TTL
 }
 
+// httpOnly refresh token cookie (set by server)
+{
+  httpOnly: true,
+  secure: true,
+  sameSite: "Lax",
+  path: "/",
+  maxAge: 604800,      // 7 days — longer-lived than access token
+}
+
 // Indicator cookie (set by client JS)
 {
   expires: 1,          // 1 day
@@ -181,14 +233,18 @@ Customer domain: portal.acme.com
 
 | File | Role |
 |------|------|
-| `src/server/utils/authCookie.js` | Server-side cookie utility (set, clear, read) |
-| `pages/api/signin.js` | Password sign-in — sets httpOnly cookie |
-| `pages/api/sign-in-with-idp.js` | IDP sign-in — sets httpOnly cookie |
-| `pages/api/idp-auth.js` | Legacy IDP callback (Google/GitHub direct) — sets httpOnly cookie |
-| `pages/api/logout.js` | Clears httpOnly cookie, calls backend logout |
+| `src/server/utils/authCookie.js` | Server-side cookie utility (set, clear, read access + refresh tokens) |
+| `src/server/utils/extractBackendCookies.js` | Extracts refresh token from backend Set-Cookie headers |
+| `pages/api/signin.js` | Password sign-in — sets httpOnly access + refresh cookies |
+| `pages/api/sign-in-with-idp.js` | IDP sign-in — sets httpOnly access + refresh cookies |
+| `pages/api/idp-auth.js` | Legacy IDP callback (Google/GitHub direct) — sets httpOnly cookies |
+| `pages/api/logout.js` | Clears both httpOnly cookies, calls backend logout |
+| `pages/api/refresh-token.js` | Server-side token refresh — reads refresh cookie, calls backend, sets new access token |
 | `pages/api/action.js` | API proxy — reads cookie, adds Authorization header |
-| `src/api/client.ts` | openapi-fetch client — uses indicator cookie for auth state |
+| `src/api/client.ts` | openapi-fetch client — 401 → refresh → retry → logout |
+| `src/api/refreshAuth.ts` | Client-side refresh utility with request coalescing |
 | `src/axios.js` | Axios client — no longer carries Authorization header |
+| `src/providers/AxiosGlobalErrorHandler.tsx` | Axios error handler — 401 → refresh → retry → logout |
 | `src/hooks/useLogout.js` | Client logout — calls `/api/logout`, clears indicator |
 | `proxy.js` | Middleware — reads httpOnly cookie for route protection |
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,16 +4,15 @@
 
 The customer portal uses **httpOnly cookies** for authentication. JWT tokens are managed entirely server-side — client-side JavaScript never has access to the raw token. This mitigates XSS-based token theft.
 
-### Cross-Domain Architecture
+---
+
+## Cross-Domain Architecture
 
 The customer portal and the Omnistrate backend API run on **different domains**:
-- Customer portal: `portal.acme.com` (varies per customer)
+- Customer portal: `portal.acme.com` (varies per customer deployment)
 - Backend API: `api.omnistrate.cloud` (fixed)
 
-Because they are different origins, the backend **cannot** set cookies on the customer portal's domain. Instead, the Next.js server acts as an intermediary:
-1. The Next.js server receives JWT tokens from the backend in response bodies
-2. The Next.js server sets httpOnly cookies on its own domain (same-origin with the browser)
-3. On subsequent requests, the Next.js server reads the cookie and adds the `Authorization: Bearer` header to backend calls
+Because they are different origins, the backend **cannot** set cookies on the customer portal's domain. Instead, the Next.js server acts as an intermediary — it receives tokens from the backend in response bodies and Set-Cookie headers, then re-sets them as httpOnly cookies on its own domain:
 
 ```
 Browser ←──same-origin──→ Next.js Server ──cross-domain──→ Backend API
@@ -21,19 +20,68 @@ Browser ←──same-origin──→ Next.js Server ──cross-domain──→
                               sets Auth header)               Auth header)
 ```
 
-### Cookie Summary
+> **Contrast with Omnistrate Cloud UI**: In the Cloud UI, the browser and API share `*.omnistrate.cloud`, so the backend sets httpOnly cookies directly via `Set-Cookie` headers. No server intermediary is needed. See the [Cloud UI authentication doc](../../omnistrate-cloud-ui/docs/authentication.md) for that architecture.
 
-Three cookies are used:
+### Why This Works on Any Customer Domain
+
+The customer portal can run on **any domain** (e.g., `portal.acme.com`, `app.example.io`):
+
+1. **All API calls are same-origin.** The browser only communicates with the Next.js server on the same domain. The server forwards requests to the backend. There are no cross-origin requests from the browser.
+2. **Cookies are always first-party.** The httpOnly cookie is set by the Next.js server (same domain as the browser). `SameSite=Lax` works everywhere.
+3. **No domain configuration needed.** The cookie `Path=/` applies to whatever domain the portal is hosted on.
+
+```
+Customer domain: portal.acme.com
+  │
+  ├── Browser ←→ portal.acme.com (Next.js)     ← same-origin, cookies work
+  │                    │
+  │                    └──→ api.omnistrate.cloud  ← server-to-server, no cookies needed
+```
+
+---
+
+## Cookie Summary
 
 | Cookie | Name | Type | Set By | Purpose |
 |--------|------|------|--------|---------|
-| Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | Next.js server | Holds the JWT. Set and read only by the server. |
-| Refresh token | `omnistrate_refresh_token` | httpOnly, Secure, SameSite=Lax | Next.js server | Holds the refresh token. Used to obtain a new JWT when the current one expires. |
-| Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | Browser (js-cookie) | Lets the UI know the user is authenticated. |
+| Access token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax, 1-day TTL | Next.js server | Holds the JWT. Set and read only by the server. |
+| Refresh token | `omnistrate_refresh_token` | httpOnly, Secure, SameSite=Lax, 7-day TTL | Next.js server | Used to obtain a new JWT when the access token expires. |
+| Indicator | `omnistrate_logged_in` | Regular (JS-accessible), Secure, SameSite=Lax, 1-day TTL | Browser (js-cookie) | Lets the UI know the user is authenticated. Carries no sensitive data. |
 
-## How It Works
+### Cookie Configuration
 
-### Sign-In Flow
+```javascript
+// httpOnly access token (set by Next.js server in authCookie.js)
+{
+  httpOnly: true,
+  secure: true,        // HTTPS only
+  sameSite: "Lax",     // blocks cross-origin POST/PUT/DELETE
+  path: "/",           // available to all routes
+  maxAge: 86400,       // 1 day — matches backend token TTL
+}
+
+// httpOnly refresh token (set by Next.js server in authCookie.js)
+{
+  httpOnly: true,
+  secure: true,
+  sameSite: "Lax",
+  path: "/",
+  maxAge: 604800,      // 7 days — longer-lived than access token
+}
+
+// Indicator cookie (set by client JS via js-cookie)
+{
+  secure: true,
+  sameSite: "Lax",
+  expires: 1,          // 1 day
+}
+```
+
+---
+
+## Authentication Flows
+
+### Sign-In
 
 ```
 Browser                    Next.js Server              Backend API
@@ -45,35 +93,32 @@ Browser                    Next.js Server              Backend API
   │                             │◄── { jwtToken: "..." } ──┤
   │                             │    Set-Cookie: refresh_token=...
   │                             │                          │
-  │                             │── (extracts jwtToken +   │
-  │                             │   refresh token from     │
-  │                             │   backend response,      │
-  │                             │   sets httpOnly cookies)  │
+  │                             │── Extracts jwtToken from │
+  │                             │   body + refresh token   │
+  │                             │   from Set-Cookie header │
+  │                             │── Sets httpOnly cookies   │
   │                             │                          │
   │◄── 200 OK ─────────────────┤                          │
   │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
   │    Set-Cookie: omnistrate_refresh_token=...; HttpOnly  │
-  │    (no tokens in body)      │                          │
+  │    Body: { ...rest }        │  (no tokens in body)     │
   │                             │                          │
   ├─ Sets omnistrate_logged_in  │                          │
   │  indicator cookie (JS)      │                          │
   ├─ Redirects to /instances    │                          │
 ```
 
-1. The browser sends credentials to `/api/signin` (Next.js API route).
-2. The Next.js server calls the backend (cross-domain), receives the JWT in the response body and potentially a refresh token via Set-Cookie headers.
-3. The **Next.js server** sets the JWT as an httpOnly cookie (`omnistrate_token`) on its response to the browser — the backend cannot set cookies on the customer's domain because it's a different origin. The token never appears in the response body sent to the browser.
-4. If the backend returns a refresh token, the server also stores it as `omnistrate_refresh_token` (httpOnly).
-5. The client sets a regular `omnistrate_logged_in` indicator cookie for UI state (route guards, request gating).
+1. Browser sends credentials to `/api/signin` (Next.js API route — same-origin).
+2. Next.js server calls the backend (cross-domain), receives the JWT in the response body and potentially a refresh token via `Set-Cookie` headers.
+3. The server sets `omnistrate_token` (httpOnly) from the JWT. The token is stripped from the response body sent to the browser.
+4. If the backend returns a refresh token in `Set-Cookie`, the server captures it and sets `omnistrate_refresh_token` (httpOnly).
+5. The client sets the `omnistrate_logged_in` indicator cookie for UI state.
 
-The same flow applies to IDP (SSO) sign-in via `/api/sign-in-with-idp`.
+The same flow applies to IDP (SSO) sign-in via `/api/sign-in-with-idp` and the legacy `/api/idp-auth` callback.
 
 ### Authenticated API Requests
 
-All client-side API calls are proxied through the Next.js server via `POST /api/action`.
-The server reads the httpOnly cookie and adds the `Authorization: Bearer` header before
-forwarding to the backend (since the backend is on a different domain, browsers won't
-send the cookie directly to it):
+All client-side API calls are proxied through `POST /api/action`. The server reads the httpOnly cookie and adds the `Authorization: Bearer` header:
 
 ```
 Browser                    Next.js Server              Backend API
@@ -84,23 +129,65 @@ Browser                    Next.js Server              Backend API
   │  (httpOnly cookie sent      │                          │
   │   automatically, same-origin)│                         │
   │                             ├─ Reads omnistrate_token   │
-  │                             │  from request cookies     │
+  │                             │  from cookie              │
   │                             │                          │
   │                             ├─ GET/POST/... endpoint ──►│
   │                             │  Authorization: Bearer <token>
-  │                             │  (header set by server    │
-  │                             │   from cookie value)      │
   │                             │                          │
   │                             │◄── response ──────────────┤
   │◄── response ────────────────┤                          │
 ```
 
-1. The browser sends requests to `/api/action` with request metadata (endpoint, method, data).
-2. The `omnistrate_token` httpOnly cookie is sent automatically by the browser (same-origin request to Next.js server).
-3. The **Next.js server** reads the token from the cookie and adds the `Authorization: Bearer` header to the backend call — this is necessary because the backend is on a different domain and cannot receive the cookie directly.
+1. Browser sends a request to `/api/action` with metadata (endpoint, method, data).
+2. The `omnistrate_token` cookie is included automatically (same-origin).
+3. The server reads the token and sets the `Authorization: Bearer` header for the backend.
 4. The response is forwarded back to the browser.
 
-### Logout Flow
+### 401 Handling & Silent Token Refresh
+
+When an API response returns 401, the client attempts a silent refresh before logging out:
+
+```
+Browser                    Next.js Server              Backend API
+  │                             │                     (different domain)
+  │                             │                          │
+  ├─ Request returns 401        │                          │
+  │                             │                          │
+  ├─ POST /api/refresh-token ──►│                          │
+  │  (httpOnly refresh cookie   │                          │
+  │   sent automatically)       │                          │
+  │                             ├─ Reads omnistrate_       │
+  │                             │  refresh_token cookie     │
+  │                             │                          │
+  │                             ├─ POST /refresh-token ───►│
+  │                             │  Cookie: refresh_token=...│
+  │                             │                          │
+  │                             │◄── new JWT / Set-Cookie ─┤
+  │                             │                          │
+  │                             │── Sets new               │
+  │                             │   omnistrate_token cookie │
+  │                             │                          │
+  │◄── 200 OK ─────────────────┤                          │
+  │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
+  │                             │                          │
+  ├─ Refreshes indicator cookie │                          │
+  ├─ Retries original request   │                          │
+```
+
+**Flow (both openapi-fetch client and Axios interceptors):**
+
+1. On 401, `refreshAuth()` calls `POST /api/refresh-token` (same-origin, httpOnly cookies included).
+2. The Next.js server reads `omnistrate_refresh_token` from the cookie.
+3. The server forwards it to the backend's `/refresh-token` endpoint.
+4. If the backend returns a new JWT (in body or `Set-Cookie`), the server stores it as the new `omnistrate_token` cookie.
+5. The client refreshes the indicator cookie and retries the original request — the new cookie is sent automatically.
+6. If refresh fails or the retry still returns 401, the user is logged out and redirected to `/signin`.
+
+**Coalescing:** Multiple concurrent 401s share a single refresh request (via a shared promise) to avoid hammering the endpoint.
+
+**Graceful degradation:** If the backend doesn't issue a refresh token on signin, the refresh attempt simply fails and the user is redirected to sign in — same as the pre-refresh behavior.
+
+### Logout
 
 ```
 Browser                    Next.js Server              Backend API
@@ -115,142 +202,93 @@ Browser                    Next.js Server              Backend API
   │◄── 200 OK ─────────────────┤                          │
   │    Set-Cookie: omnistrate_token=; Max-Age=0            │
   │    Set-Cookie: omnistrate_refresh_token=; Max-Age=0    │
-  │    (Next.js server clears   │                          │
-  │     both httpOnly cookies)  │                          │
   │                             │                          │
   ├─ Removes omnistrate_logged_in│                         │
   ├─ Broadcasts "logout" to     │                          │
-  │  other tabs                 │                          │
+  │  other tabs (BroadcastChannel)                         │
   ├─ Redirects to /signin       │                          │
 ```
 
 1. The client calls `POST /api/logout`.
-2. The Next.js server reads the httpOnly cookie, calls the backend to invalidate the token, then clears both httpOnly cookies (access + refresh, `Max-Age=0`). The backend cannot clear the cookies because it's on a different domain — the Next.js server handles it.
-3. The client removes the indicator cookie, clears local state, and redirects to `/signin`.
+2. The server reads the access token, calls the backend to invalidate it, then clears both httpOnly cookies (`Max-Age=0`).
+3. The client removes the indicator cookie, clears local state, broadcasts logout to other tabs, and redirects to `/signin`.
 
 ### Middleware (Route Protection)
 
 The Next.js middleware (`proxy.js`) runs on every navigation request:
 
-1. Reads the `omnistrate_token` httpOnly cookie (middleware runs server-side, so it can read httpOnly cookies).
+1. Reads the `omnistrate_token` httpOnly cookie (middleware runs server-side, can read httpOnly cookies).
 2. Decodes the JWT and checks expiration.
 3. Validates the token by calling `GET /user` on the backend.
 4. Redirects to `/signin` if the token is missing, expired, or invalid.
 
-### 401 Handling & Silent Token Refresh
+Excluded routes (no auth required): `/api/action`, `/api/signin`, `/api/signup`, `/api/logout`, `/api/refresh-token`, `/api/reset-password`, `/api/provider-details`, `/api/sign-in-with-idp`, `/idp-auth`, `/validate-token`, static assets, and legal pages.
 
-When any API response returns 401, the client attempts a silent token refresh before logging out:
+---
 
-```
-Browser                    Next.js Server              Backend API
-  │                             │                     (different domain)
-  │                             │                          │
-  ├─ Request returns 401 ──────►│                          │
-  │                             │                          │
-  ├─ POST /api/refresh-token ──►│                          │
-  │  (httpOnly refresh cookie   │                          │
-  │   sent automatically)       │                          │
-  │                             ├─ Reads refresh token     │
-  │                             │  from httpOnly cookie     │
-  │                             │                          │
-  │                             ├─ POST /refresh-token ───►│
-  │                             │  Cookie: refresh_token=...│
-  │                             │                          │
-  │                             │◄── new JWT / Set-Cookie ─┤
-  │                             │                          │
-  │                             │── Sets new               │
-  │                             │   omnistrate_token cookie │
-  │                             │                          │
-  │◄── 200 OK ─────────────────┤                          │
-  │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
-  │                             │                          │
-  ├─ Retries original request   │                          │
-  │  (new httpOnly cookie       │                          │
-  │   sent automatically)       │                          │
-```
+## Security Properties
 
-**Refresh flow (both openapi-fetch client and Axios):**
+### XSS Mitigation
 
-1. On 401, the client calls `POST /api/refresh-token` (same-origin, httpOnly cookies included).
-2. The Next.js server reads the `omnistrate_refresh_token` httpOnly cookie.
-3. The server forwards it to the backend's `/refresh-token` endpoint.
-4. If the backend returns a new JWT (in body or Set-Cookie), the server stores it as the new `omnistrate_token` httpOnly cookie.
-5. The client retries the original request — the new cookie is sent automatically.
-6. If refresh fails, the user is logged out and redirected to `/signin`.
+**Problem**: Traditional cookie or localStorage token storage allows any JavaScript running on the page to read the token — including injected scripts.
 
-**Coalescing:** Multiple concurrent 401s share a single refresh request to avoid hammering the endpoint.
+**Solution**: The JWT is in an httpOnly cookie. The `HttpOnly` flag prevents `document.cookie` from accessing it. Even if an attacker injects JavaScript, they **cannot exfiltrate the auth token**. The refresh token is equally protected.
 
-**Graceful degradation:** If the backend doesn't issue a refresh token on signin, the refresh attempt simply fails and the user is redirected to sign in — same as the previous behavior.
+The `omnistrate_logged_in` indicator is intentionally non-httpOnly (the UI reads it), but it carries no sensitive data — it's the string `"true"`.
 
-## Why This Architecture Works for Customer-Hosted Domains
+### CSRF Protection
 
-The customer portal can run on **any domain** (e.g., `portal.acme.com`, `app.example.io`). This works because:
+**Problem**: httpOnly cookies are sent automatically on every same-origin request, which could enable CSRF if an attacker tricks the browser into making a request.
 
-1. **All API calls are same-origin.** The browser only communicates with the Next.js server on the same domain. The server then forwards requests to the backend. There are no cross-origin requests from the browser.
+**Mitigations**:
+1. **`SameSite=Lax`**: Cookies are only sent on top-level navigations (GET) and same-site requests. Cross-origin `POST`/`PUT`/`DELETE` requests **do not include the cookie**.
+2. **POST-only mutation endpoints**: `/api/action`, `/api/logout`, and `/api/refresh-token` only accept POST. Since `SameSite=Lax` blocks cross-origin POST, CSRF is blocked.
+3. **`Secure` flag**: Cookies are only transmitted over HTTPS.
 
-2. **Cookies are always first-party.** The httpOnly cookie is set by the Next.js server (same domain as the browser) — not by a third-party backend domain. `SameSite=Lax` works everywhere.
+### Token Refresh Security
 
-3. **No domain configuration needed.** The cookie `Path=/` applies to whatever domain the portal is hosted on. No need to configure cookie domains per customer.
+- The refresh token is httpOnly — invisible to JavaScript.
+- Refresh requests are coalesced into a single in-flight request, preventing thundering herd on concurrent 401s.
+- If refresh fails, the user is immediately logged out — no infinite retry loops.
+- On logout, both access and refresh tokens are cleared.
 
-```
-Customer domain: portal.acme.com
-  │
-  ├── Browser ←→ portal.acme.com (Next.js)     ← same-origin, cookies work
-  │                    │
-  │                    └──→ api.omnistrate.cloud  ← server-to-server, no cookies needed
-```
+### Defense in Depth
 
-## Cookie Configuration
+| Layer | Mechanism |
+|-------|-----------|
+| Token storage | httpOnly cookies — invisible to JS |
+| Transport | `Secure` flag — HTTPS only |
+| Cross-site | `SameSite=Lax` — blocks cross-origin mutation requests |
+| Clickjacking | `X-Frame-Options: DENY` |
+| Token expiry | 1-day access TTL, 7-day refresh TTL |
+| Silent refresh | Automatic token renewal on 401 |
+| Session termination | Logout clears cookies + backend invalidation |
+| Multi-tab logout | `BroadcastChannel` propagates logout across tabs |
 
-```javascript
-// httpOnly auth cookie (set by server)
-{
-  httpOnly: true,
-  secure: true,        // HTTPS only
-  sameSite: "Lax",     // same-origin requests only
-  path: "/",           // available to all routes
-  maxAge: 86400,       // 1 day — matches backend token TTL
-}
+### What the Indicator Cookie Does NOT Do
 
-// httpOnly refresh token cookie (set by server)
-{
-  httpOnly: true,
-  secure: true,
-  sameSite: "Lax",
-  path: "/",
-  maxAge: 604800,      // 7 days — longer-lived than access token
-}
+The `omnistrate_logged_in` cookie is a **UX optimization**, not a security boundary:
+- It allows the API client to abort requests early when the user is clearly logged out.
+- It does **not** grant access to anything. All real authorization is performed by the backend using the httpOnly token.
+- If an attacker sets `omnistrate_logged_in=true` manually, API calls will still fail with 401 (no valid httpOnly token), triggering a logout.
 
-// Indicator cookie (set by client JS)
-{
-  expires: 1,          // 1 day
-  sameSite: "Lax",
-  secure: true,
-}
-```
+---
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `src/server/utils/authCookie.js` | Server-side cookie utility (set, clear, read access + refresh tokens) |
-| `src/server/utils/extractBackendCookies.js` | Extracts refresh token from backend Set-Cookie headers |
+| `src/server/utils/authCookie.js` | Server-side cookie utility — set, clear, read access + refresh tokens |
+| `src/server/utils/extractBackendCookies.js` | Extracts refresh token from backend `Set-Cookie` headers |
 | `pages/api/signin.js` | Password sign-in — sets httpOnly access + refresh cookies |
 | `pages/api/sign-in-with-idp.js` | IDP sign-in — sets httpOnly access + refresh cookies |
-| `pages/api/idp-auth.js` | Legacy IDP callback (Google/GitHub direct) — sets httpOnly cookies |
+| `pages/api/idp-auth.js` | Legacy IDP callback (Google/GitHub) — sets httpOnly cookies |
 | `pages/api/logout.js` | Clears both httpOnly cookies, calls backend logout |
 | `pages/api/refresh-token.js` | Server-side token refresh — reads refresh cookie, calls backend, sets new access token |
-| `pages/api/action.js` | API proxy — reads cookie, adds Authorization header |
-| `src/api/client.ts` | openapi-fetch client — 401 → refresh → retry → logout |
+| `pages/api/action.js` | API proxy — reads access cookie, adds `Authorization` header |
+| `src/api/client.ts` | openapi-fetch client — indicator checks, 401 → refresh → retry → logout |
 | `src/api/refreshAuth.ts` | Client-side refresh utility with request coalescing |
-| `src/axios.js` | Axios client — no longer carries Authorization header |
+| `src/axios.js` | Axios client — no Authorization header (server handles it) |
 | `src/providers/AxiosGlobalErrorHandler.tsx` | Axios error handler — 401 → refresh → retry → logout |
-| `src/hooks/useLogout.js` | Client logout — calls `/api/logout`, clears indicator |
+| `src/hooks/useLogout.js` | Client logout — calls `/api/logout`, clears indicator, broadcasts |
 | `proxy.js` | Middleware — reads httpOnly cookie for route protection |
-
-## Security Properties
-
-- **XSS protection**: The JWT is never accessible to client-side JavaScript. Even if an attacker injects a script, they cannot steal the auth token.
-- **CSRF protection**: `SameSite=Lax` prevents the cookie from being sent on cross-origin POST requests. The `/api/action` endpoint only accepts POST, so CSRF is blocked.
-- **Secure flag**: Cookies are only sent over HTTPS.
-- **No token in localStorage/sessionStorage**: Eliminates another common XSS exfiltration vector.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,162 @@
+# Authentication Architecture — Customer Portal
+
+## Overview
+
+The customer portal uses **httpOnly cookies** for authentication. JWT tokens are managed entirely server-side — client-side JavaScript never has access to the raw token. This mitigates XSS-based token theft.
+
+Two cookies are used:
+
+| Cookie | Name | Type | Purpose |
+|--------|------|------|---------|
+| Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | Holds the JWT. Set and read only by the server. |
+| Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | Lets the UI know the user is authenticated. |
+
+## How It Works
+
+### Sign-In Flow
+
+```
+Browser                    Next.js Server              Backend API
+  │                             │                          │
+  ├─ POST /api/signin ─────────►│                          │
+  │  { email, password }        ├─ POST /customer-user-signin ──►│
+  │                             │                          │
+  │                             │◄── { jwtToken: "..." } ──┤
+  │                             │                          │
+  │◄── Set-Cookie: omnistrate_token=...; HttpOnly; Secure ─┤
+  │◄── 200 OK (no token in body)│                          │
+  │                             │                          │
+  ├─ Sets omnistrate_logged_in  │                          │
+  │  indicator cookie (JS)      │                          │
+  ├─ Redirects to /instances    │                          │
+```
+
+1. The browser sends credentials to `/api/signin` (Next.js API route).
+2. The server calls the backend, receives the JWT in the response body.
+3. The server sets the JWT as an **httpOnly cookie** (`omnistrate_token`) on the response — the token never appears in the response body sent to the browser.
+4. The client sets a regular `omnistrate_logged_in` indicator cookie for UI state (route guards, request gating).
+
+The same flow applies to IDP (SSO) sign-in via `/api/sign-in-with-idp`.
+
+### Authenticated API Requests
+
+All client-side API calls are proxied through the Next.js server via `POST /api/action`:
+
+```
+Browser                    Next.js Server              Backend API
+  │                             │                          │
+  ├─ POST /api/action ──────────►│                          │
+  │  { endpoint, method, data } │                          │
+  │  (cookie sent automatically)│                          │
+  │                             ├─ Reads omnistrate_token   │
+  │                             │  from request cookies     │
+  │                             │                          │
+  │                             ├─ GET/POST/... endpoint ──►│
+  │                             │  Authorization: Bearer <token>
+  │                             │                          │
+  │                             │◄── response ──────────────┤
+  │◄── response ────────────────┤                          │
+```
+
+1. The browser sends requests to `/api/action` with request metadata (endpoint, method, data).
+2. The `omnistrate_token` httpOnly cookie is sent automatically by the browser (same-origin).
+3. The server reads the token from the cookie and adds the `Authorization: Bearer` header to the backend call.
+4. The response is forwarded back to the browser.
+
+### Logout Flow
+
+```
+Browser                    Next.js Server              Backend API
+  │                             │                          │
+  ├─ POST /api/logout ──────────►│                          │
+  │                             ├─ POST /logout ───────────►│
+  │                             │  Authorization: Bearer <token>
+  │                             │                          │
+  │◄── Set-Cookie: omnistrate_token=; Max-Age=0 ───────────┤
+  │                             │                          │
+  ├─ Removes omnistrate_logged_in│                         │
+  ├─ Broadcasts "logout" to     │                          │
+  │  other tabs                 │                          │
+  ├─ Redirects to /signin       │                          │
+```
+
+1. The client calls `POST /api/logout`.
+2. The server calls the backend to invalidate the token, then clears the httpOnly cookie.
+3. The client removes the indicator cookie, clears local state, and redirects to `/signin`.
+
+### Middleware (Route Protection)
+
+The Next.js middleware (`proxy.js`) runs on every navigation request:
+
+1. Reads the `omnistrate_token` httpOnly cookie (middleware runs server-side, so it can read httpOnly cookies).
+2. Decodes the JWT and checks expiration.
+3. Validates the token by calling `GET /user` on the backend.
+4. Redirects to `/signin` if the token is missing, expired, or invalid.
+
+### 401 Handling
+
+When any API response returns 401:
+
+- The **openapi-fetch client** (`src/api/client.ts`) removes the `omnistrate_logged_in` indicator cookie, clears localStorage, and redirects to `/signin`.
+- The **Axios error handler** (`AxiosGlobalErrorHandler.tsx`) calls the logout handler which does the same.
+
+The httpOnly cookie is left as-is on 401 — it will be overwritten on the next sign-in or cleared by the middleware redirect.
+
+## Why This Architecture Works for Customer-Hosted Domains
+
+The customer portal can run on **any domain** (e.g., `portal.acme.com`, `app.example.io`). This works because:
+
+1. **All API calls are same-origin.** The browser only communicates with the Next.js server on the same domain. The server then forwards requests to the backend. There are no cross-origin requests from the browser.
+
+2. **Cookies are always first-party.** The httpOnly cookie is set by the Next.js server (same domain as the browser) — not by a third-party backend domain. `SameSite=Lax` works everywhere.
+
+3. **No domain configuration needed.** The cookie `Path=/` applies to whatever domain the portal is hosted on. No need to configure cookie domains per customer.
+
+```
+Customer domain: portal.acme.com
+  │
+  ├── Browser ←→ portal.acme.com (Next.js)     ← same-origin, cookies work
+  │                    │
+  │                    └──→ api.omnistrate.cloud  ← server-to-server, no cookies needed
+```
+
+## Cookie Configuration
+
+```javascript
+// httpOnly auth cookie (set by server)
+{
+  httpOnly: true,
+  secure: true,        // HTTPS only
+  sameSite: "Lax",     // same-origin requests only
+  path: "/",           // available to all routes
+  maxAge: 86400,       // 1 day — matches backend token TTL
+}
+
+// Indicator cookie (set by client JS)
+{
+  expires: 1,          // 1 day
+  sameSite: "Lax",
+  secure: true,
+}
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/server/utils/authCookie.js` | Server-side cookie utility (set, clear, read) |
+| `pages/api/signin.js` | Password sign-in — sets httpOnly cookie |
+| `pages/api/sign-in-with-idp.js` | IDP sign-in — sets httpOnly cookie |
+| `pages/api/logout.js` | Clears httpOnly cookie, calls backend logout |
+| `pages/api/action.js` | API proxy — reads cookie, adds Authorization header |
+| `src/api/client.ts` | openapi-fetch client — uses indicator cookie for auth state |
+| `src/axios.js` | Axios client — no longer carries Authorization header |
+| `src/hooks/useLogout.js` | Client logout — calls `/api/logout`, clears indicator |
+| `proxy.js` | Middleware — reads httpOnly cookie for route protection |
+
+## Security Properties
+
+- **XSS protection**: The JWT is never accessible to client-side JavaScript. Even if an attacker injects a script, they cannot steal the auth token.
+- **CSRF protection**: `SameSite=Lax` prevents the cookie from being sent on cross-origin POST requests. The `/api/action` endpoint only accepts POST, so CSRF is blocked.
+- **Secure flag**: Cookies are only sent over HTTPS.
+- **No token in localStorage/sessionStorage**: Eliminates another common XSS exfiltration vector.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,12 +4,31 @@
 
 The customer portal uses **httpOnly cookies** for authentication. JWT tokens are managed entirely server-side — client-side JavaScript never has access to the raw token. This mitigates XSS-based token theft.
 
+### Cross-Domain Architecture
+
+The customer portal and the Omnistrate backend API run on **different domains**:
+- Customer portal: `portal.acme.com` (varies per customer)
+- Backend API: `api.omnistrate.cloud` (fixed)
+
+Because they are different origins, the backend **cannot** set cookies on the customer portal's domain. Instead, the Next.js server acts as an intermediary:
+1. The Next.js server receives JWT tokens from the backend in response bodies
+2. The Next.js server sets httpOnly cookies on its own domain (same-origin with the browser)
+3. On subsequent requests, the Next.js server reads the cookie and adds the `Authorization: Bearer` header to backend calls
+
+```
+Browser ←──same-origin──→ Next.js Server ──cross-domain──→ Backend API
+  (cookies work here)        (reads cookie,                  (receives
+                              sets Auth header)               Auth header)
+```
+
+### Cookie Summary
+
 Two cookies are used:
 
-| Cookie | Name | Type | Purpose |
-|--------|------|------|---------|
-| Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | Holds the JWT. Set and read only by the server. |
-| Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | Lets the UI know the user is authenticated. |
+| Cookie | Name | Type | Set By | Purpose |
+|--------|------|------|--------|---------|
+| Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | Next.js server | Holds the JWT. Set and read only by the server. |
+| Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | Browser (js-cookie) | Lets the UI know the user is authenticated. |
 
 ## How It Works
 
@@ -17,14 +36,19 @@ Two cookies are used:
 
 ```
 Browser                    Next.js Server              Backend API
+  │                             │                     (different domain)
   │                             │                          │
   ├─ POST /api/signin ─────────►│                          │
   │  { email, password }        ├─ POST /customer-user-signin ──►│
   │                             │                          │
   │                             │◄── { jwtToken: "..." } ──┤
   │                             │                          │
-  │◄── Set-Cookie: omnistrate_token=...; HttpOnly; Secure ─┤
-  │◄── 200 OK (no token in body)│                          │
+  │                             │── (extracts jwtToken,    │
+  │                             │   sets httpOnly cookie)   │
+  │                             │                          │
+  │◄── 200 OK ─────────────────┤                          │
+  │    Set-Cookie: omnistrate_token=...; HttpOnly; Secure  │
+  │    (no token in body)       │                          │
   │                             │                          │
   ├─ Sets omnistrate_logged_in  │                          │
   │  indicator cookie (JS)      │                          │
@@ -32,47 +56,60 @@ Browser                    Next.js Server              Backend API
 ```
 
 1. The browser sends credentials to `/api/signin` (Next.js API route).
-2. The server calls the backend, receives the JWT in the response body.
-3. The server sets the JWT as an **httpOnly cookie** (`omnistrate_token`) on the response — the token never appears in the response body sent to the browser.
+2. The Next.js server calls the backend (cross-domain), receives the JWT in the response body.
+3. The **Next.js server** sets the JWT as an httpOnly cookie (`omnistrate_token`) on its response to the browser — the backend cannot set cookies on the customer's domain because it's a different origin. The token never appears in the response body sent to the browser.
 4. The client sets a regular `omnistrate_logged_in` indicator cookie for UI state (route guards, request gating).
 
 The same flow applies to IDP (SSO) sign-in via `/api/sign-in-with-idp`.
 
 ### Authenticated API Requests
 
-All client-side API calls are proxied through the Next.js server via `POST /api/action`:
+All client-side API calls are proxied through the Next.js server via `POST /api/action`.
+The server reads the httpOnly cookie and adds the `Authorization: Bearer` header before
+forwarding to the backend (since the backend is on a different domain, browsers won't
+send the cookie directly to it):
 
 ```
 Browser                    Next.js Server              Backend API
+  │                             │                     (different domain)
   │                             │                          │
   ├─ POST /api/action ──────────►│                          │
   │  { endpoint, method, data } │                          │
-  │  (cookie sent automatically)│                          │
+  │  (httpOnly cookie sent      │                          │
+  │   automatically, same-origin)│                         │
   │                             ├─ Reads omnistrate_token   │
   │                             │  from request cookies     │
   │                             │                          │
   │                             ├─ GET/POST/... endpoint ──►│
   │                             │  Authorization: Bearer <token>
+  │                             │  (header set by server    │
+  │                             │   from cookie value)      │
   │                             │                          │
   │                             │◄── response ──────────────┤
   │◄── response ────────────────┤                          │
 ```
 
 1. The browser sends requests to `/api/action` with request metadata (endpoint, method, data).
-2. The `omnistrate_token` httpOnly cookie is sent automatically by the browser (same-origin).
-3. The server reads the token from the cookie and adds the `Authorization: Bearer` header to the backend call.
+2. The `omnistrate_token` httpOnly cookie is sent automatically by the browser (same-origin request to Next.js server).
+3. The **Next.js server** reads the token from the cookie and adds the `Authorization: Bearer` header to the backend call — this is necessary because the backend is on a different domain and cannot receive the cookie directly.
 4. The response is forwarded back to the browser.
 
 ### Logout Flow
 
 ```
 Browser                    Next.js Server              Backend API
+  │                             │                     (different domain)
   │                             │                          │
   ├─ POST /api/logout ──────────►│                          │
+  │                             ├─ Reads omnistrate_token   │
+  │                             │  from cookie              │
   │                             ├─ POST /logout ───────────►│
   │                             │  Authorization: Bearer <token>
   │                             │                          │
-  │◄── Set-Cookie: omnistrate_token=; Max-Age=0 ───────────┤
+  │◄── 200 OK ─────────────────┤                          │
+  │    Set-Cookie: omnistrate_token=; Max-Age=0            │
+  │    (Next.js server clears   │                          │
+  │     the httpOnly cookie)    │                          │
   │                             │                          │
   ├─ Removes omnistrate_logged_in│                         │
   ├─ Broadcasts "logout" to     │                          │
@@ -81,7 +118,7 @@ Browser                    Next.js Server              Backend API
 ```
 
 1. The client calls `POST /api/logout`.
-2. The server calls the backend to invalidate the token, then clears the httpOnly cookie.
+2. The Next.js server reads the httpOnly cookie, calls the backend to invalidate the token, then clears the httpOnly cookie (sets `Max-Age=0`). The backend cannot clear the cookie because it's on a different domain — the Next.js server handles it.
 3. The client removes the indicator cookie, clears local state, and redirects to `/signin`.
 
 ### Middleware (Route Protection)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -147,6 +147,7 @@ Customer domain: portal.acme.com
 | `src/server/utils/authCookie.js` | Server-side cookie utility (set, clear, read) |
 | `pages/api/signin.js` | Password sign-in — sets httpOnly cookie |
 | `pages/api/sign-in-with-idp.js` | IDP sign-in — sets httpOnly cookie |
+| `pages/api/idp-auth.js` | Legacy IDP callback (Google/GitHub direct) — sets httpOnly cookie |
 | `pages/api/logout.js` | Clears httpOnly cookie, calls backend logout |
 | `pages/api/action.js` | API proxy — reads cookie, adds Authorization header |
 | `src/api/client.ts` | openapi-fetch client — uses indicator cookie for auth state |

--- a/pages/api/action.js
+++ b/pages/api/action.js
@@ -62,7 +62,7 @@ export default async function handleAction(nextRequest, nextResponse) {
             query: queryParams,
           },
           headers: {
-            Authorization: authorization,
+            ...(authorization ? { Authorization: authorization } : {}),
             "Client-IP": clientIP,
             "SaaSBuilder-IP": saasBuilderIP,
             "User-Agent": customUserAgent,

--- a/pages/api/action.js
+++ b/pages/api/action.js
@@ -1,6 +1,7 @@
 import createFetchClient from "openapi-fetch";
 
 import { baseDomain } from "src/api/client";
+import { getAuthToken } from "src/server/utils/authCookie";
 import { isAllowedRoute, normalizeEndpoint } from "src/server/utils/allowedRoutes";
 import { httpRequestMethods } from "src/server/utils/constants/httpsRequestMethods";
 import { isPasswordSameAsEmail, passwordMatchesEmailText, passwordRegex, passwordText as passwordRegexFailText } from "src/utils/passwordRegex";
@@ -52,12 +53,16 @@ export default async function handleAction(nextRequest, nextResponse) {
         const customUserAgent = `customer-portal/${appVersion} (${originalUserAgent})`;
 
         // Prepare request options
+        // Read auth token from httpOnly cookie (primary) or Authorization header (fallback)
+        const authToken = getAuthToken(nextRequest);
+        const authorization = authToken ? `Bearer ${authToken}` : nextRequest.headers.authorization;
+
         const requestOptions = {
           params: {
             query: queryParams,
           },
           headers: {
-            Authorization: nextRequest.headers.authorization,
+            Authorization: authorization,
             "Client-IP": clientIP,
             "SaaSBuilder-IP": saasBuilderIP,
             "User-Agent": customUserAgent,

--- a/pages/api/download-installer.js
+++ b/pages/api/download-installer.js
@@ -22,8 +22,8 @@ export default async function handler(req, res) {
     return res.status(400).json({ message: "Invalid download path" });
   }
 
-  // Auth: prefer Authorization header, fall back to "token" cookie
-  const authToken = req.headers.authorization || (req.cookies?.token ? `Bearer ${req.cookies.token}` : "");
+  // Auth: prefer Authorization header, fall back to httpOnly auth cookie
+  const authToken = req.headers.authorization || (req.cookies?.omnistrate_token ? `Bearer ${req.cookies.omnistrate_token}` : "");
 
   // Read filename from top-level query/body param
   const reqFilename = isGet ? req.query.filename : req.body?.filename;

--- a/pages/api/idp-auth.js
+++ b/pages/api/idp-auth.js
@@ -1,5 +1,6 @@
 import { customerSignInWithIdentityProvider } from "src/server/api/customer-user";
 import { getSaaSDomainURL } from "src/server/utils/getSaaSDomainURL";
+const { setAuthCookie } = require("src/server/utils/authCookie");
 
 export default async function handleAuth(nextRequest, nextResponse) {
   if (nextRequest.method === "GET") {
@@ -27,8 +28,9 @@ export default async function handleAuth(nextRequest, nextResponse) {
       try {
         const response = await customerSignInWithIdentityProvider(authRequestPayload);
         const jwtToken = response.data.jwtToken;
-        nextResponse.setHeader("Set-Cookie", `token=${jwtToken}; Path=/`);
-        nextResponse.setHeader("Access-Control-Expose-Headers", "Set-Cookie");
+        if (jwtToken) {
+          setAuthCookie(nextResponse, jwtToken);
+        }
         nextResponse.redirect(307, "/signin");
       } catch (err) {
         console.log("IDP AUTH err", err);

--- a/pages/api/idp-auth.js
+++ b/pages/api/idp-auth.js
@@ -1,6 +1,7 @@
 import { customerSignInWithIdentityProvider } from "src/server/api/customer-user";
 import { getSaaSDomainURL } from "src/server/utils/getSaaSDomainURL";
-const { setAuthCookie } = require("src/server/utils/authCookie");
+const { setAuthCookie, setRefreshCookie } = require("src/server/utils/authCookie");
+const { extractBackendRefreshToken } = require("src/server/utils/extractBackendCookies");
 
 export default async function handleAuth(nextRequest, nextResponse) {
   if (nextRequest.method === "GET") {
@@ -30,6 +31,10 @@ export default async function handleAuth(nextRequest, nextResponse) {
         const jwtToken = response.data.jwtToken;
         if (jwtToken) {
           setAuthCookie(nextResponse, jwtToken);
+        }
+        const refreshToken = extractBackendRefreshToken(response);
+        if (refreshToken) {
+          setRefreshCookie(nextResponse, refreshToken);
         }
         nextResponse.redirect(307, "/signin");
       } catch (err) {

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,0 +1,30 @@
+const { clearAuthCookie, getAuthToken } = require("src/server/utils/authCookie");
+const { baseDomain } = require("src/api/client");
+
+export default async function handleLogout(nextRequest, nextResponse) {
+  if (nextRequest.method === "POST") {
+    try {
+      const authToken = getAuthToken(nextRequest);
+
+      // Call backend logout to invalidate the token
+      if (authToken) {
+        await fetch(`${baseDomain}/2022-09-01-00/logout`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        }).catch((error) => {
+          console.error("Backend logout request failed", error);
+        });
+      }
+    } catch (error) {
+      console.error("Error during logout", error);
+    } finally {
+      // Always clear the httpOnly cookie, even if backend call fails
+      clearAuthCookie(nextResponse);
+      nextResponse.status(200).send({ message: "Logged out" });
+    }
+  } else {
+    nextResponse.status(404).json({ message: "Endpoint not found" });
+  }
+}

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,4 +1,4 @@
-const { clearAuthCookie, getAuthToken } = require("src/server/utils/authCookie");
+const { clearAuthCookie, clearRefreshCookie, getAuthToken } = require("src/server/utils/authCookie");
 
 const baseDomain = process.env.NEXT_PUBLIC_BACKEND_BASE_DOMAIN || "https://api.omnistrate.cloud";
 
@@ -21,8 +21,9 @@ export default async function handleLogout(nextRequest, nextResponse) {
     } catch (error) {
       console.error("Error during logout", error);
     } finally {
-      // Always clear the httpOnly cookie, even if backend call fails
+      // Always clear both httpOnly cookies, even if backend call fails
       clearAuthCookie(nextResponse);
+      clearRefreshCookie(nextResponse);
       nextResponse.status(200).send({ message: "Logged out" });
     }
   } else {

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,5 +1,6 @@
 const { clearAuthCookie, getAuthToken } = require("src/server/utils/authCookie");
-const { baseDomain } = require("src/api/client");
+
+const baseDomain = process.env.NEXT_PUBLIC_BACKEND_BASE_DOMAIN || "https://api.omnistrate.cloud";
 
 export default async function handleLogout(nextRequest, nextResponse) {
   if (nextRequest.method === "POST") {
@@ -25,6 +26,7 @@ export default async function handleLogout(nextRequest, nextResponse) {
       nextResponse.status(200).send({ message: "Logged out" });
     }
   } else {
-    nextResponse.status(404).json({ message: "Endpoint not found" });
+    nextResponse.setHeader("Allow", "POST");
+    nextResponse.status(405).json({ message: "Method not allowed" });
   }
 }

--- a/pages/api/refresh-token.js
+++ b/pages/api/refresh-token.js
@@ -1,0 +1,73 @@
+const { setAuthCookie, setRefreshCookie, clearAuthCookie, clearRefreshCookie, getRefreshToken } = require("src/server/utils/authCookie");
+
+const baseDomain = process.env.NEXT_PUBLIC_BACKEND_BASE_DOMAIN || "https://api.omnistrate.cloud";
+
+/**
+ * Server-side refresh token endpoint.
+ *
+ * Reads the refresh token from our httpOnly cookie, sends it to the backend's
+ * /refresh-token endpoint, and stores the new access token as an httpOnly cookie.
+ *
+ * This is necessary because the customer portal runs on a different domain than the
+ * backend, so the backend cannot set cookies on the portal's domain directly.
+ */
+export default async function handleRefreshToken(nextRequest, nextResponse) {
+  if (nextRequest.method !== "POST") {
+    nextResponse.setHeader("Allow", "POST");
+    return nextResponse.status(405).json({ message: "Method not allowed" });
+  }
+
+  const refreshToken = getRefreshToken(nextRequest);
+  if (!refreshToken) {
+    return nextResponse.status(401).json({ message: "No refresh token" });
+  }
+
+  try {
+    const backendResponse = await fetch(`${baseDomain}/2022-09-01-00/refresh-token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `refresh_token=${refreshToken}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    if (!backendResponse.ok) {
+      // Refresh failed — clear cookies so user can re-authenticate
+      clearAuthCookie(nextResponse);
+      clearRefreshCookie(nextResponse);
+      return nextResponse.status(401).json({ message: "Refresh failed" });
+    }
+
+    // The backend may return a new access token in the response body or via Set-Cookie
+    const data = await backendResponse.json().catch(() => ({}));
+
+    // If the backend returns the new JWT in the body, store it
+    if (data.jwtToken) {
+      setAuthCookie(nextResponse, data.jwtToken);
+    }
+
+    // Capture new tokens from Set-Cookie headers (backend may rotate tokens)
+    const setCookieHeaders = backendResponse.headers.getSetCookie?.() || [];
+    for (const header of setCookieHeaders) {
+      // Look for access token
+      const accessMatch = header.match(/(?:omnistrate_token|token)=([^;]+)/i);
+      if (accessMatch?.[1]) {
+        setAuthCookie(nextResponse, accessMatch[1]);
+      }
+
+      // Look for rotated refresh token
+      const refreshMatch = header.match(/(?:refresh_token|omnistrate_refresh_token|refreshToken)=([^;]+)/i);
+      if (refreshMatch?.[1]) {
+        setRefreshCookie(nextResponse, refreshMatch[1]);
+      }
+    }
+
+    return nextResponse.status(200).json({ message: "Token refreshed" });
+  } catch (error) {
+    console.error("Error refreshing token", error);
+    clearAuthCookie(nextResponse);
+    clearRefreshCookie(nextResponse);
+    return nextResponse.status(401).json({ message: "Refresh failed" });
+  }
+}

--- a/pages/api/sign-in-with-idp.js
+++ b/pages/api/sign-in-with-idp.js
@@ -1,6 +1,7 @@
 const { customerSignInWithIdentityProvider } = require("src/server/api/customer-user");
 const { getEnvironmentType } = require("src/server/utils/getEnvironmentType");
-const { setAuthCookie } = require("src/server/utils/authCookie");
+const { setAuthCookie, setRefreshCookie } = require("src/server/utils/authCookie");
+const { extractBackendRefreshToken } = require("src/server/utils/extractBackendCookies");
 import { getSaaSDomainURL } from "src/server/utils/getSaaSDomainURL";
 
 export default async function handleSignIn(nextRequest, nextResponse) {
@@ -30,6 +31,12 @@ export default async function handleSignIn(nextRequest, nextResponse) {
 
       if (jwtToken) {
         setAuthCookie(nextResponse, jwtToken);
+      }
+
+      // Capture any refresh token the backend returns via Set-Cookie header
+      const refreshToken = extractBackendRefreshToken(response);
+      if (refreshToken) {
+        setRefreshCookie(nextResponse, refreshToken);
       }
 
       nextResponse.status(200).send({ ...rest });

--- a/pages/api/sign-in-with-idp.js
+++ b/pages/api/sign-in-with-idp.js
@@ -1,5 +1,6 @@
 const { customerSignInWithIdentityProvider } = require("src/server/api/customer-user");
 const { getEnvironmentType } = require("src/server/utils/getEnvironmentType");
+const { setAuthCookie } = require("src/server/utils/authCookie");
 import { getSaaSDomainURL } from "src/server/utils/getSaaSDomainURL";
 
 export default async function handleSignIn(nextRequest, nextResponse) {
@@ -25,7 +26,13 @@ export default async function handleSignIn(nextRequest, nextResponse) {
         "SaaSBuilder-IP": saasBuilderIP,
       });
 
-      nextResponse.status(200).send({ ...response.data });
+      const { jwtToken, ...rest } = response.data || {};
+
+      if (jwtToken) {
+        setAuthCookie(nextResponse, jwtToken);
+      }
+
+      nextResponse.status(200).send({ ...rest });
     } catch (error) {
       console.log("IDP Error", error);
       const defaultErrorMessage = "Someting went wrong. Please retry";

--- a/pages/api/signin.js
+++ b/pages/api/signin.js
@@ -3,7 +3,8 @@ import _ from "lodash";
 import { getProviderUsers } from "src/server/api/provider-users";
 const { customerUserSignIn } = require("src/server/api/customer-user");
 const { getEnvironmentType } = require("src/server/utils/getEnvironmentType");
-const { setAuthCookie } = require("src/server/utils/authCookie");
+const { setAuthCookie, setRefreshCookie } = require("src/server/utils/authCookie");
+const { extractBackendRefreshToken } = require("src/server/utils/extractBackendCookies");
 import CaptchaVerificationError from "src/server/errors/CaptchaVerificationError";
 import { checkReCaptchaSetup } from "src/server/utils/checkReCaptchaSetup";
 import { verifyRecaptchaToken } from "src/server/utils/verifyRecaptchaToken";
@@ -50,6 +51,12 @@ export default async function handleSignIn(nextRequest, nextResponse) {
       // Set httpOnly cookie with the JWT token — the client never sees the raw token
       if (jwtToken) {
         setAuthCookie(nextResponse, jwtToken);
+      }
+
+      // Capture any refresh token the backend returns via Set-Cookie header
+      const refreshToken = extractBackendRefreshToken(response);
+      if (refreshToken) {
+        setRefreshCookie(nextResponse, refreshToken);
       }
 
       nextResponse.status(200).send({ ...rest });

--- a/pages/api/signin.js
+++ b/pages/api/signin.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 import { getProviderUsers } from "src/server/api/provider-users";
 const { customerUserSignIn } = require("src/server/api/customer-user");
 const { getEnvironmentType } = require("src/server/utils/getEnvironmentType");
+const { setAuthCookie } = require("src/server/utils/authCookie");
 import CaptchaVerificationError from "src/server/errors/CaptchaVerificationError";
 import { checkReCaptchaSetup } from "src/server/utils/checkReCaptchaSetup";
 import { verifyRecaptchaToken } from "src/server/utils/verifyRecaptchaToken";
@@ -44,7 +45,14 @@ export default async function handleSignIn(nextRequest, nextResponse) {
       });
 
       const responseData = response?.data || {};
-      nextResponse.status(200).send({ ...responseData });
+      const { jwtToken, ...rest } = responseData;
+
+      // Set httpOnly cookie with the JWT token — the client never sees the raw token
+      if (jwtToken) {
+        setAuthCookie(nextResponse, jwtToken);
+      }
+
+      nextResponse.status(200).send({ ...rest });
     } catch (error) {
       console.error("Error in sign in", error);
       let defaultErrorMessage = "Failed to sign in. Either the credentials are incorrect or the user does not exist";

--- a/proxy.js
+++ b/proxy.js
@@ -80,6 +80,6 @@ export async function proxy(request) {
 
 export const config = {
   matcher: [
-    "/((?!api/action|api/signup|api/signin|api/logout|api/reset-password|api/provider-details|idp-auth|api/sign-in-with-idp|privacy-policy|cookie-policy|terms-of-use|favicon.ico|_next/image|_next/static|static|validate-token).*)",
+    "/((?!api/action|api/signup|api/signin|api/logout|api/refresh-token|api/reset-password|api/provider-details|idp-auth|api/sign-in-with-idp|privacy-policy|cookie-policy|terms-of-use|favicon.ico|_next/image|_next/static|static|validate-token).*)",
   ],
 };

--- a/proxy.js
+++ b/proxy.js
@@ -8,7 +8,7 @@ import { getEnvironmentType } from "src/server/utils/getEnvironmentType";
 const environmentType = getEnvironmentType();
 
 export async function proxy(request) {
-  const authToken = request.cookies.get("token");
+  const authToken = request.cookies.get("omnistrate_token");
   const path = request.nextUrl.pathname;
 
   if (path.startsWith("/signup") || path.startsWith("/reset-password") || path.startsWith("/change-password")) {
@@ -80,6 +80,6 @@ export async function proxy(request) {
 
 export const config = {
   matcher: [
-    "/((?!api/action|api/signup|api/signin|api/reset-password|api/provider-details|idp-auth|api/sign-in-with-idp|privacy-policy|cookie-policy|terms-of-use|favicon.ico|_next/image|_next/static|static|validate-token).*)",
+    "/((?!api/action|api/signup|api/signin|api/logout|api/reset-password|api/provider-details|idp-auth|api/sign-in-with-idp|privacy-policy|cookie-policy|terms-of-use|favicon.ico|_next/image|_next/static|static|validate-token).*)",
   ],
 };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,7 @@ import Cookies from "js-cookie";
 import createFetchClient from "openapi-fetch";
 
 import { paths } from "src/types/schema";
+import { refreshAuth } from "./refreshAuth";
 import { checkIsNonProtectedEndpoint } from "src/utils/authUtils";
 
 export const baseDomain = process.env.NEXT_PUBLIC_BACKEND_BASE_DOMAIN || "https://api.omnistrate.cloud";
@@ -106,6 +107,17 @@ apiClient.use({
       if (response.status === 401) {
         // Check if this isn't the signin URL to avoid redirect loops
         if (!response.url.endsWith("/signin")) {
+          // Attempt silent token refresh before forcing logout
+          const refreshed = await refreshAuth();
+          if (refreshed) {
+            // Retry the original request — the new httpOnly cookie is sent automatically
+            const retryResponse = await fetch(request.clone(), { credentials: "include" });
+            if (retryResponse.ok) {
+              return retryResponse;
+            }
+          }
+
+          // Refresh failed or retry still 401 — force logout
           Cookies.remove("omnistrate_logged_in");
           localStorage.removeItem("paymentNotificationHidden");
           try {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -19,18 +19,15 @@ apiClient.use({
     const pathname = url.pathname;
 
     const isProtectedEndpoint = !checkIsNonProtectedEndpoint(pathname);
-    const hasAuthToken = typeof document !== "undefined" && !!Cookies.get("token");
+    const hasAuth = typeof document !== "undefined" && !!Cookies.get("omnistrate_logged_in");
 
-    if (isProtectedEndpoint && !hasAuthToken) {
+    if (isProtectedEndpoint && !hasAuth) {
       const controller = new AbortController();
       controller.abort("Request aborted due to missing auth token");
       return new Request(request, { signal: controller.signal });
     }
 
-    const token = Cookies.get("token");
-    if (token) {
-      request.headers.set("Authorization", `Bearer ${token}`);
-    }
+    // Authorization header is added server-side by /api/action using the httpOnly cookie
 
     if (!pathname.startsWith("/api") && pathname.startsWith("/")) {
       // Store original request details
@@ -109,7 +106,7 @@ apiClient.use({
       if (response.status === 401) {
         // Check if this isn't the signin URL to avoid redirect loops
         if (!response.url.endsWith("/signin")) {
-          Cookies.remove("token");
+          Cookies.remove("omnistrate_logged_in");
           localStorage.removeItem("paymentNotificationHidden");
           try {
             localStorage.removeItem("loggedInUsingSSO");

--- a/src/api/refreshAuth.ts
+++ b/src/api/refreshAuth.ts
@@ -1,0 +1,54 @@
+import Cookies from "js-cookie";
+
+const AUTH_INDICATOR_COOKIE = "omnistrate_logged_in";
+
+// Shared refresh state: ensures only one refresh request is in-flight at a time.
+// Concurrent 401s queue behind the same promise instead of hammering the endpoint.
+let refreshPromise: Promise<boolean> | null = null;
+
+/**
+ * Attempt to silently refresh the access token via the server-side refresh endpoint.
+ *
+ * In the customer portal, the browser never touches the raw tokens — the Next.js server
+ * reads the httpOnly refresh token cookie, calls the backend's /refresh-token endpoint,
+ * and sets a new httpOnly access token cookie.
+ *
+ * Returns true if refresh succeeded, false if the user must re-authenticate.
+ */
+export async function refreshAuth(): Promise<boolean> {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  refreshPromise = doRefresh();
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
+async function doRefresh(): Promise<boolean> {
+  try {
+    const response = await fetch("/api/refresh-token", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.ok) {
+      // Server set new httpOnly access token cookie via Set-Cookie header.
+      // Refresh the indicator cookie so the UI knows we're still authenticated.
+      Cookies.set(AUTH_INDICATOR_COOKIE, "true", {
+        sameSite: "Lax",
+        secure: window.location.protocol === "https:",
+        expires: 1, // 1 day
+      });
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/src/axios.js
+++ b/src/axios.js
@@ -1,5 +1,4 @@
 const Axios = require("axios");
-const Cookies = require("js-cookie");
 
 const baseDomain = process.env.NEXT_PUBLIC_BACKEND_BASE_DOMAIN || "https://api.omnistrate.cloud";
 
@@ -7,9 +6,6 @@ const baseURL = baseDomain + "/2022-09-01-00";
 
 const axios = Axios.create({
   baseURL,
-  headers: {
-    Authorization: "Bearer " + Cookies.get("token"),
-  },
   ignoreGlobalErrorSnack: false,
 });
 

--- a/src/cookieConsentManager.js
+++ b/src/cookieConsentManager.js
@@ -6,7 +6,7 @@ export const getCookieConsentInitialObject = (googleAnalyticsTagID) => {
       {
         category: "necessary",
         services: [
-          { type: "auth", name: "token", cookies: ["token"] },
+          { type: "auth", name: "omnistrate_token", cookies: ["omnistrate_token", "omnistrate_logged_in"] },
           { type: "OAuth_providers", name: "OAuth" },
         ],
         hide: false,

--- a/src/hooks/useInstallerDownload.ts
+++ b/src/hooks/useInstallerDownload.ts
@@ -17,7 +17,7 @@ type DownloadState = {
  * 2. Opens it via a hidden `<a>` tag click — this triggers the browser download bar
  * 3. The browser handles progress, pause/resume, and file saving automatically
  *
- * Auth is read from the "token" cookie on the server side, so no
+ * Auth is read from the httpOnly "omnistrate_token" cookie on the server side, so no
  * Authorization header is needed — the cookie is sent automatically
  * with the browser navigation request.
  */

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -4,7 +4,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import Cookies from "js-cookie";
 import { useDispatch } from "react-redux";
 
-import axios from "src/axios";
 import { logoutBroadcastChannel } from "src/broadcastChannel";
 import { initialiseUserData } from "src/slices/userDataSlice";
 
@@ -14,9 +13,9 @@ function useLogout() {
   const pathname = usePathname();
   const queryClient = useQueryClient();
 
-  // remove token from cookies, remove other user data and redirect to signin
+  // remove indicator cookie, clear user data and redirect to signin
   function handleLogout() {
-    Cookies.remove("token");
+    Cookies.remove("omnistrate_logged_in");
     localStorage.removeItem("paymentNotificationHidden");
     try {
       localStorage.removeItem("loggedInUsingSSO");
@@ -34,12 +33,11 @@ function useLogout() {
     }
   }, [pathname]);
 
-  // make backend call and invalidate the token
+  // call server-side logout to clear httpOnly cookie and invalidate the token
   function logout() {
-    axios
-      .post("/logout")
+    fetch("/api/logout", { method: "POST" })
       .catch((error) => {
-        console.log("Logout request failed", error);
+        console.error("Logout request failed", error);
       })
       .finally(() => {
         handleLogout();

--- a/src/providers/AxiosGlobalErrorHandler.tsx
+++ b/src/providers/AxiosGlobalErrorHandler.tsx
@@ -23,9 +23,9 @@ const AxiosGlobalErrorHandler = () => {
 
       // cancel the request if auth cookie is missing for protected endpoints
       const isProtectedEndpoint = !checkIsNonProtectedEndpoint(config.url || "");
-      const hasAuthToken = typeof document !== "undefined" && !!Cookies.get("token");
+      const hasAuth = typeof document !== "undefined" && !!Cookies.get("omnistrate_logged_in");
 
-      if (isProtectedEndpoint && !hasAuthToken) {
+      if (isProtectedEndpoint && !hasAuth) {
         // Abort this request with AbortController
         const controller = new AbortController();
         config.signal = controller.signal;

--- a/src/providers/AxiosGlobalErrorHandler.tsx
+++ b/src/providers/AxiosGlobalErrorHandler.tsx
@@ -5,6 +5,7 @@ import _ from "lodash";
 
 import axios, { baseURL } from "src/axios";
 import useLogout from "src/hooks/useLogout";
+import { refreshAuth } from "src/api/refreshAuth";
 import { checkIsNonProtectedEndpoint } from "src/utils/authUtils";
 
 const AxiosGlobalErrorHandler = () => {
@@ -75,6 +76,12 @@ const AxiosGlobalErrorHandler = () => {
 
         if (error.response && error.response.status === 401) {
           if (`${baseURL}/signin` !== error.request.responseURL) {
+            // Attempt silent token refresh before forcing logout
+            const refreshed = await refreshAuth();
+            if (refreshed) {
+              // Retry the original request with the new httpOnly cookie
+              return axios.request(error.config);
+            }
             handleLogout();
           }
         } else if (!ignoreGlobalErrorSnack) {

--- a/src/server/utils/authCookie.js
+++ b/src/server/utils/authCookie.js
@@ -1,0 +1,73 @@
+const COOKIE_NAME = "omnistrate_token";
+const INDICATOR_COOKIE_NAME = "omnistrate_logged_in";
+
+// 1 day in seconds — matches backend token TTL
+const MAX_AGE = 86400;
+
+/**
+ * Sets the httpOnly auth cookie on the response.
+ * @param {import("next").NextApiResponse} res
+ * @param {string} token - JWT token
+ */
+function setAuthCookie(res, token) {
+  const cookie = [
+    `${COOKIE_NAME}=${token}`,
+    `Path=/`,
+    `HttpOnly`,
+    `Secure`,
+    `SameSite=Lax`,
+    `Max-Age=${MAX_AGE}`,
+  ].join("; ");
+
+  appendSetCookieHeader(res, cookie);
+}
+
+/**
+ * Clears the httpOnly auth cookie by setting Max-Age=0.
+ * @param {import("next").NextApiResponse} res
+ */
+function clearAuthCookie(res) {
+  const cookie = [
+    `${COOKIE_NAME}=`,
+    `Path=/`,
+    `HttpOnly`,
+    `Secure`,
+    `SameSite=Lax`,
+    `Max-Age=0`,
+  ].join("; ");
+
+  appendSetCookieHeader(res, cookie);
+}
+
+/**
+ * Reads the auth token from the request cookies.
+ * Works with both Pages API routes (req.cookies) and middleware (request.cookies.get()).
+ * @param {import("next").NextApiRequest} req
+ * @returns {string | undefined}
+ */
+function getAuthToken(req) {
+  // Pages API routes: req.cookies is a plain object
+  if (req.cookies && typeof req.cookies === "object" && !req.cookies.get) {
+    return req.cookies[COOKIE_NAME];
+  }
+  // Middleware: request.cookies is a RequestCookies instance
+  return req.cookies?.get(COOKIE_NAME)?.value;
+}
+
+/**
+ * Appends a Set-Cookie header without overwriting existing ones.
+ */
+function appendSetCookieHeader(res, cookie) {
+  const existing = res.getHeader("Set-Cookie") || [];
+  const cookies = Array.isArray(existing) ? existing : [existing];
+  res.setHeader("Set-Cookie", [...cookies, cookie]);
+}
+
+module.exports = {
+  COOKIE_NAME,
+  INDICATOR_COOKIE_NAME,
+  MAX_AGE,
+  setAuthCookie,
+  clearAuthCookie,
+  getAuthToken,
+};

--- a/src/server/utils/authCookie.js
+++ b/src/server/utils/authCookie.js
@@ -1,8 +1,11 @@
 const COOKIE_NAME = "omnistrate_token";
+const REFRESH_COOKIE_NAME = "omnistrate_refresh_token";
 const INDICATOR_COOKIE_NAME = "omnistrate_logged_in";
 
 // 1 day in seconds — matches backend token TTL
 const MAX_AGE = 86400;
+// 7 days for refresh token
+const REFRESH_MAX_AGE = 604800;
 
 /**
  * Sets the httpOnly auth cookie on the response.
@@ -23,12 +26,47 @@ function setAuthCookie(res, token) {
 }
 
 /**
+ * Sets the httpOnly refresh token cookie on the response.
+ * @param {import("next").NextApiResponse} res
+ * @param {string} refreshToken
+ */
+function setRefreshCookie(res, refreshToken) {
+  const cookie = [
+    `${REFRESH_COOKIE_NAME}=${refreshToken}`,
+    `Path=/`,
+    `HttpOnly`,
+    `Secure`,
+    `SameSite=Lax`,
+    `Max-Age=${REFRESH_MAX_AGE}`,
+  ].join("; ");
+
+  appendSetCookieHeader(res, cookie);
+}
+
+/**
  * Clears the httpOnly auth cookie by setting Max-Age=0.
  * @param {import("next").NextApiResponse} res
  */
 function clearAuthCookie(res) {
   const cookie = [
     `${COOKIE_NAME}=`,
+    `Path=/`,
+    `HttpOnly`,
+    `Secure`,
+    `SameSite=Lax`,
+    `Max-Age=0`,
+  ].join("; ");
+
+  appendSetCookieHeader(res, cookie);
+}
+
+/**
+ * Clears the httpOnly refresh token cookie by setting Max-Age=0.
+ * @param {import("next").NextApiResponse} res
+ */
+function clearRefreshCookie(res) {
+  const cookie = [
+    `${REFRESH_COOKIE_NAME}=`,
     `Path=/`,
     `HttpOnly`,
     `Secure`,
@@ -55,6 +93,18 @@ function getAuthToken(req) {
 }
 
 /**
+ * Reads the refresh token from the request cookies.
+ * @param {import("next").NextApiRequest} req
+ * @returns {string | undefined}
+ */
+function getRefreshToken(req) {
+  if (req.cookies && typeof req.cookies === "object" && !req.cookies.get) {
+    return req.cookies[REFRESH_COOKIE_NAME];
+  }
+  return req.cookies?.get(REFRESH_COOKIE_NAME)?.value;
+}
+
+/**
  * Appends a Set-Cookie header without overwriting existing ones.
  */
 function appendSetCookieHeader(res, cookie) {
@@ -65,9 +115,14 @@ function appendSetCookieHeader(res, cookie) {
 
 module.exports = {
   COOKIE_NAME,
+  REFRESH_COOKIE_NAME,
   INDICATOR_COOKIE_NAME,
   MAX_AGE,
+  REFRESH_MAX_AGE,
   setAuthCookie,
+  setRefreshCookie,
   clearAuthCookie,
+  clearRefreshCookie,
   getAuthToken,
+  getRefreshToken,
 };

--- a/src/server/utils/extractBackendCookies.js
+++ b/src/server/utils/extractBackendCookies.js
@@ -1,0 +1,29 @@
+/**
+ * Extracts the refresh token from Set-Cookie headers in a backend (axios) response.
+ *
+ * When the Next.js server calls the backend for signin, the backend may include
+ * a refresh token as a Set-Cookie header. Since the customer portal runs on a
+ * different domain, these cookies can't reach the browser directly — we capture
+ * the value here so it can be re-set as our own httpOnly cookie.
+ *
+ * @param {import("axios").AxiosResponse} response - Axios response from the backend
+ * @returns {string | undefined} The refresh token value, or undefined if not found
+ */
+function extractBackendRefreshToken(response) {
+  const setCookieHeaders = response?.headers?.["set-cookie"];
+  if (!setCookieHeaders) return undefined;
+
+  const headers = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+
+  for (const header of headers) {
+    // Match common refresh token cookie names the backend may use
+    const match = header.match(/(?:refresh_token|omnistrate_refresh_token|refreshToken)=([^;]+)/i);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return undefined;
+}
+
+module.exports = { extractBackendRefreshToken };

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -14,6 +14,7 @@ export function checkIsNonProtectedEndpoint(url: string): boolean {
     "/health",
     "/json-schema",
     "/login-with-identity-provider",
+    "/refresh-token",
     "/reset-password",
     "/resource-instance/health",
     "/resource-instance/version",

--- a/test-utils/user-api-client.ts
+++ b/test-utils/user-api-client.ts
@@ -16,11 +16,14 @@ export class UserAPIClient {
       data: { email, password },
     });
 
-    const data = await response.json();
-    const token = data.jwtToken;
+    // Token is now in an httpOnly cookie set by the server, not in the response body
+    const headers = response.headers();
+    const setCookies = headers["set-cookie"] || "";
+    const tokenMatch = setCookies.match(/omnistrate_token=([^;]+)/);
+    const token = tokenMatch?.[1];
 
     if (!token) {
-      throw new Error("Failed to login");
+      throw new Error("Failed to login — omnistrate_token cookie not found in response");
     }
 
     GlobalStateManager.setState({ userToken: token });

--- a/tests/auth/signin.spec.ts
+++ b/tests/auth/signin.spec.ts
@@ -164,14 +164,17 @@ test.describe("Signin Page", () => {
     // intercept the request to the identity provider auth endpoint "/api/sign-in-with-idp
     await page.route("**/api/sign-in-with-idp", async (route) => {
       try {
-        // Return mock successful response with httpOnly cookie
+        // Mock must set the httpOnly cookie (like the real server does),
+        // otherwise middleware will block the redirect to /instances
         await route.fulfill({
           status: 200,
           contentType: "application/json",
           headers: {
             "Set-Cookie": `omnistrate_token=${userToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=86400`,
           },
-          body: JSON.stringify({}),
+          body: JSON.stringify({
+            jwtToken: userToken,
+          }),
         });
       } catch (error) {
         console.log("Error in route handler:", error);

--- a/tests/auth/signin.spec.ts
+++ b/tests/auth/signin.spec.ts
@@ -164,13 +164,14 @@ test.describe("Signin Page", () => {
     // intercept the request to the identity provider auth endpoint "/api/sign-in-with-idp
     await page.route("**/api/sign-in-with-idp", async (route) => {
       try {
-        // Return mock successful response
+        // Return mock successful response with httpOnly cookie
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({
-            jwtToken: userToken,
-          }),
+          headers: {
+            "Set-Cookie": `omnistrate_token=${userToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=86400`,
+          },
+          body: JSON.stringify({}),
         });
       } catch (error) {
         console.log("Error in route handler:", error);

--- a/tests/user-setup.spec.ts
+++ b/tests/user-setup.spec.ts
@@ -15,11 +15,16 @@ setup("Authenticate User", async ({ page }) => {
 
   await signinPage.signInWithPassword();
 
-  // Intercept the Request to Get the JWT Token
-  const request = await page.waitForResponse((response) => response.url().includes("/api/signin"));
-  const response = await request.json();
+  // Wait for the signin response — token is now in an httpOnly cookie, not the response body
+  await page.waitForResponse((response) => response.url().includes("/api/signin"));
   console.log("User signin successful!");
-  GlobalStateManager.setState({ userToken: response.jwtToken });
+
+  // Read the httpOnly token from browser cookies
+  const cookies = await page.context().cookies();
+  const tokenCookie = cookies.find((c) => c.name === "omnistrate_token");
+  if (tokenCookie) {
+    GlobalStateManager.setState({ userToken: tokenCookie.value });
+  }
 
   // Intercept the Request to Get Subscriptions
   const subscriptionsData = await page.waitForResponse(


### PR DESCRIPTION
## Summary

Migrate authentication from JS-accessible `token` cookie to server-side **httpOnly** `omnistrate_token` cookie. The JWT token is no longer accessible to client-side JavaScript, mitigating XSS-based token theft.

## Architecture

Since all client API calls already proxy through the Next.js server (`/api/action`), httpOnly cookies work seamlessly on **any customer-hosted domain** — everything stays same-origin.

| Cookie | Name | Type | Purpose |
|--------|------|------|---------|
| Auth token | `omnistrate_token` | httpOnly, Secure, SameSite=Lax | JWT — set/read only by server |
| Indicator | `omnistrate_logged_in` | Regular (JS-accessible) | UI auth state (route guards, request gating) |

## Changes

### Server-side (token never leaves the server)
- **`src/server/utils/authCookie.js`** — New server-side cookie utility (set, clear, read)
- **`pages/api/signin.js`** — Sets httpOnly cookie, strips `jwtToken` from response body
- **`pages/api/sign-in-with-idp.js`** — Same pattern for IDP sign-in
- **`pages/api/logout.js`** — New endpoint: clears httpOnly cookie + calls backend logout
- **`pages/api/action.js`** — Reads httpOnly cookie → sets Authorization header for backend calls
- **`pages/api/download-installer.js`** — Updated to read new cookie name

### Client-side (no more token access)
- **`SignInForm.tsx`** — Sets `omnistrate_logged_in` indicator instead of `token`, removed axios/token handling
- **`idp-auth/page.tsx`** — Same pattern
- **`src/api/client.ts`** — Uses indicator cookie for auth state checks, no longer sets Authorization header
- **`src/axios.js`** — Removed Authorization from default headers
- **`useLogout.js`** — Calls `/api/logout` to clear httpOnly cookie, clears indicator
- **`AxiosGlobalErrorHandler.tsx`** — Uses indicator cookie for auth state checks
- **`proxy.js`** — Reads `omnistrate_token` cookie, excludes `/api/logout` from auth

### Documentation
- **`docs/authentication.md`** — New: explains the full auth architecture, flow diagrams, and why it works on any customer domain

## Security Properties
- **XSS protection**: JWT is never accessible to client-side JavaScript
- **CSRF protection**: `SameSite=Lax` blocks cross-origin POST requests
- **Secure flag**: Cookies only sent over HTTPS
- **No token in localStorage/sessionStorage**

## How to Test
1. Sign in with password — verify `omnistrate_token` (httpOnly) and `omnistrate_logged_in` cookies are set
2. Make API calls — verify requests succeed (server reads cookie, adds Authorization)
3. Sign in with IDP — verify same cookie behavior
4. Logout — verify both cookies are cleared
5. Direct API call without cookie — verify 401 redirect
6. Check browser DevTools → Application → Cookies: `omnistrate_token` should show as httpOnly