### PR TITLE
fix: Resolve Dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "next-nprogress-bar": "^2.4.3",
     "next-plugin-yaml": "^1.0.1",
     "node-cron": "^3.0.3",
-    "nodemailer": "8.0.5",
+    "nodemailer": "^8.0.5",
     "openapi-fetch": "^0.14.0",
     "openapi-react-query": "^0.5.0",
     "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tanstack/react-query": "^5.77.1",
     "@tanstack/react-table": "^8.20.5",
     "ansi-to-react": "^6.1.6",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "buffer": "^6.0.3",
     "clipboardy": "^3.0.0",
     "clsx": "^2.1.1",
@@ -55,11 +55,11 @@
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
     "monaco-editor": "^0.52.0",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "next-nprogress-bar": "^2.4.3",
     "next-plugin-yaml": "^1.0.1",
     "node-cron": "^3.0.3",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "8.0.5",
     "openapi-fetch": "^0.14.0",
     "openapi-react-query": "^0.5.0",
     "prop-types": "^15.6.0",
@@ -106,7 +106,8 @@
     "wait-on": "^9.0.4"
   },
   "resolutions": {
-    "axios": "1.13.5"
+    "axios": "1.15.0",
+    "basic-ftp": "5.2.2"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/src/axios.d.ts
+++ b/src/axios.d.ts
@@ -1,0 +1,23 @@
+import { AxiosInstance, AxiosRequestConfig as BaseAxiosRequestConfig } from "axios";
+
+interface CustomAxiosRequestConfig<D = any> extends BaseAxiosRequestConfig<D> {
+  /** When true, suppresses the global error snackbar for this request */
+  ignoreGlobalErrorSnack?: boolean;
+}
+
+interface CustomAxiosInstance extends Omit<AxiosInstance, "get" | "post" | "put" | "patch" | "delete" | "head" | "options" | "request"> {
+  request<T = any, R = import("axios").AxiosResponse<T>, D = any>(config: CustomAxiosRequestConfig<D>): Promise<R>;
+  get<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  delete<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  head<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  options<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  post<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, data?: D, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  put<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, data?: D, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+  patch<T = any, R = import("axios").AxiosResponse<T>, D = any>(url: string, data?: D, config?: CustomAxiosRequestConfig<D>): Promise<R>;
+}
+
+declare const axios: CustomAxiosInstance;
+
+export default axios;
+export declare const baseURL: string;
+export declare const baseDomain: string;

--- a/src/components/RestoreInstance/CopySnapshotModal.tsx
+++ b/src/components/RestoreInstance/CopySnapshotModal.tsx
@@ -29,8 +29,7 @@ type CopySnapshotModalProps = {
   handleClose: () => void;
   offering: ServiceOffering;
   cloudProvider?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  copySnapshotMutation: UseMutationResult<any, Error, { targetRegion: string }, unknown>;
+  copySnapshotMutation: UseMutationResult<unknown, Error, { targetRegion: string }, unknown>;
   snapshotCreationType: SnapshotCreationType | null;
   tab?: "backups" | "snapshots";
 };

--- a/src/components/RestoreInstance/CopySnapshotModal.tsx
+++ b/src/components/RestoreInstance/CopySnapshotModal.tsx
@@ -29,7 +29,8 @@ type CopySnapshotModalProps = {
   handleClose: () => void;
   offering: ServiceOffering;
   cloudProvider?: string;
-  copySnapshotMutation: UseMutationResult<void, Error, { targetRegion: string }, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  copySnapshotMutation: UseMutationResult<any, Error, { targetRegion: string }, unknown>;
   snapshotCreationType: SnapshotCreationType | null;
   tab?: "backups" | "snapshots";
 };

--- a/src/components/RestoreInstance/CustomNetworkSelectionStep.tsx
+++ b/src/components/RestoreInstance/CustomNetworkSelectionStep.tsx
@@ -25,8 +25,7 @@ import { Text } from "../Typography/Typography";
 
 type CustomNetworkSelectionStepProps = {
   handleClose: () => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  restoreInstanceMutation: UseMutationResult<any, Error, { customNetwork?: string }, unknown>;
+  restoreInstanceMutation: UseMutationResult<unknown, Error, { customNetwork?: string }, unknown>;
   cloudProvider?: string;
   region: string;
   customNetworks: CustomNetwork[];

--- a/src/components/RestoreInstance/CustomNetworkSelectionStep.tsx
+++ b/src/components/RestoreInstance/CustomNetworkSelectionStep.tsx
@@ -25,7 +25,8 @@ import { Text } from "../Typography/Typography";
 
 type CustomNetworkSelectionStepProps = {
   handleClose: () => void;
-  restoreInstanceMutation: UseMutationResult<void, Error, { customNetwork?: string }, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  restoreInstanceMutation: UseMutationResult<any, Error, { customNetwork?: string }, unknown>;
   cloudProvider?: string;
   region: string;
   customNetworks: CustomNetwork[];

--- a/src/providers/AxiosGlobalErrorHandler.tsx
+++ b/src/providers/AxiosGlobalErrorHandler.tsx
@@ -18,8 +18,8 @@ const AxiosGlobalErrorHandler = () => {
   }
 
   useEffect(() => {
-    axios.interceptors.request.use((config) => {
-      const isCliDownload = /^\/service\/[^/]+\/service-api\/[^/]+\/cli$/.test(config.url);
+    const requestInterceptorId = axios.interceptors.request.use((config) => {
+      const isCliDownload = /^\/service\/[^/]+\/service-api\/[^/]+\/cli$/.test(config.url ?? "");
 
       // cancel the request if auth cookie is missing for protected endpoints
       const isProtectedEndpoint = !checkIsNonProtectedEndpoint(config.url || "");
@@ -33,7 +33,7 @@ const AxiosGlobalErrorHandler = () => {
         return config; // Axios will reject the request after seeing the aborted signal
       }
 
-      if (!config.url.startsWith("/api") && config.url.startsWith("/") && !isCliDownload) {
+      if (config.url && !config.url.startsWith("/api") && config.url.startsWith("/") && !isCliDownload) {
         //the original request url
         const originalRequestURL = config.url;
         //the original request method
@@ -66,7 +66,7 @@ const AxiosGlobalErrorHandler = () => {
       return config;
     });
 
-    axios.interceptors.response.use(
+    const responseInterceptorId = axios.interceptors.response.use(
       (response) => {
         return response;
       },
@@ -109,8 +109,8 @@ const AxiosGlobalErrorHandler = () => {
     );
 
     return () => {
-      axios.interceptors.request.eject();
-      axios.interceptors.response.eject();
+      axios.interceptors.request.eject(requestInterceptorId);
+      axios.interceptors.response.eject(responseInterceptorId);
     };
   }, [handleLogout]);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "types": ["node"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "types": [
+      "node"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -9,19 +15,33 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "src/*": ["src/*"],
-      "components/*": ["src/components/*"],
-      "hooks/*": ["src/hooks/*"],
-      "utils/*": ["src/utils/*"],
-      "public/*": ["public/*"],
-      "lib/*": ["lib/*"],
-      "@/components/*": ["components/*"]
+      "src/*": [
+        "src/*"
+      ],
+      "components/*": [
+        "src/components/*"
+      ],
+      "hooks/*": [
+        "src/hooks/*"
+      ],
+      "utils/*": [
+        "src/utils/*"
+      ],
+      "public/*": [
+        "public/*"
+      ],
+      "lib/*": [
+        "lib/*"
+      ],
+      "@/components/*": [
+        "components/*"
+      ]
     },
     "target": "es5",
     "forceConsistentCasingInFileNames": true,
@@ -41,5 +61,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,10 +1245,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/env@npm:16.1.7"
-  checksum: 10c0/89a9e657b29d01be04394cd8a4c917cfdd76aec76ea9a0f7670896efe7668e665713adcf72632958b0c19ce66cf7e1f39961cfd9ba69d10c5a3e08ee20d2370a
+"@next/env@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/env@npm:16.2.3"
+  checksum: 10c0/56c3fee8ea226efe59ef065e054380f872c00c45c9fe4475eaa45f80773c3c1adc3ead3ccdd77447d3c1aeb4b3004aaaa033dd4a100d3e572fd01b83f992dde8
   languageName: node
   linkType: hard
 
@@ -1261,58 +1261,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-darwin-arm64@npm:16.1.7"
+"@next/swc-darwin-arm64@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-darwin-arm64@npm:16.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-darwin-x64@npm:16.1.7"
+"@next/swc-darwin-x64@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-darwin-x64@npm:16.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.1.7"
+"@next/swc-linux-arm64-gnu@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-linux-arm64-musl@npm:16.1.7"
+"@next/swc-linux-arm64-musl@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-linux-x64-gnu@npm:16.1.7"
+"@next/swc-linux-x64-gnu@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-linux-x64-musl@npm:16.1.7"
+"@next/swc-linux-x64-musl@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.1.7"
+"@next/swc-win32-arm64-msvc@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.1.7":
-  version: 16.1.7
-  resolution: "@next/swc-win32-x64-msvc@npm:16.1.7"
+"@next/swc-win32-x64-msvc@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3379,14 +3379,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/abf468c34f2d145f3dc7dbc0f1be67e520630624307bda69a41bbe8d386bd672d87b4405c4ee77f9ff54b235ab02f96a9968fb00e75b13ce64706e352a3068fd
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -3538,10 +3538,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10c0/a0f85c01deae0723021f9bf4a7be29378186fa8bba41e74ea11832fe74c187ce90c3599c3cc5ec936581cfd150020e79f4a9ed0ee9fb20b2308e69b045f3a059
+"basic-ftp@npm:5.2.2":
+  version: 5.2.2
+  resolution: "basic-ftp@npm:5.2.2"
+  checksum: 10c0/a314a05450cf6311035d1bbb23c1ba1c8c0b991e7cb9bfafafc72a82bfafc540561c22eb046a58374688b7b9df502aa002fc28f4d366eb40964f307d131e06a6
   languageName: node
   linkType: hard
 
@@ -7900,24 +7900,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.1.7":
-  version: 16.1.7
-  resolution: "next@npm:16.1.7"
+"next@npm:16.2.3":
+  version: 16.2.3
+  resolution: "next@npm:16.2.3"
   dependencies:
-    "@next/env": "npm:16.1.7"
-    "@next/swc-darwin-arm64": "npm:16.1.7"
-    "@next/swc-darwin-x64": "npm:16.1.7"
-    "@next/swc-linux-arm64-gnu": "npm:16.1.7"
-    "@next/swc-linux-arm64-musl": "npm:16.1.7"
-    "@next/swc-linux-x64-gnu": "npm:16.1.7"
-    "@next/swc-linux-x64-musl": "npm:16.1.7"
-    "@next/swc-win32-arm64-msvc": "npm:16.1.7"
-    "@next/swc-win32-x64-msvc": "npm:16.1.7"
+    "@next/env": "npm:16.2.3"
+    "@next/swc-darwin-arm64": "npm:16.2.3"
+    "@next/swc-darwin-x64": "npm:16.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:16.2.3"
+    "@next/swc-linux-arm64-musl": "npm:16.2.3"
+    "@next/swc-linux-x64-gnu": "npm:16.2.3"
+    "@next/swc-linux-x64-musl": "npm:16.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:16.2.3"
+    "@next/swc-win32-x64-msvc": "npm:16.2.3"
     "@swc/helpers": "npm:0.5.15"
     baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
-    sharp: "npm:^0.34.4"
+    sharp: "npm:^0.34.5"
     styled-jsx: "npm:5.1.6"
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
@@ -7956,7 +7956,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/f6cebb3ce57d267cd92fb364b56710004c883baafea9cfed36434c0cd51db74299d59094ab782674d9813f10ce2891b633bc6d94e7e38aa9af7a1870194818d0
+  checksum: 10c0/8a9d27fc773d69f7f471cf1a23bde2ab2950e0411ef3e0d5c1664ed9654e94c3304eae1c4283ec0fa4e70e7b3f4416913350e118e0c18e8b055693dc5d021883
   languageName: node
   linkType: hard
 
@@ -8090,10 +8090,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "nodemailer@npm:8.0.4"
-  checksum: 10c0/5fb6fa72645b541c18b84b861de46f4740449e1d7c987b4d9ef715d815d613f93262225bc319e217df6215d6f123efadb9a412dcf937fe0a41cbecf279dfb2a0
+"nodemailer@npm:8.0.5":
+  version: 8.0.5
+  resolution: "nodemailer@npm:8.0.5"
+  checksum: 10c0/5e8450499bd059c56d74ba96fa5f9928de2ecdae0d53c083dba5661d797114c1f9524d30f992d0263cc5a7dcf5a54b9c1d92dc1f766da150c9d0bde7d3798431
   languageName: node
   linkType: hard
 
@@ -8281,7 +8281,7 @@ __metadata:
     "@types/react-google-recaptcha": "npm:^2.1.9"
     ansi-to-react: "npm:^6.1.6"
     autoprefixer: "npm:^10.4.20"
-    axios: "npm:1.13.5"
+    axios: "npm:1.15.0"
     buffer: "npm:^6.0.3"
     clipboardy: "npm:^3.0.0"
     clsx: "npm:^2.1.1"
@@ -8305,12 +8305,12 @@ __metadata:
     jwt-decode: "npm:^4.0.0"
     lodash: "npm:^4.18.1"
     monaco-editor: "npm:^0.52.0"
-    next: "npm:16.1.7"
+    next: "npm:16.2.3"
     next-nprogress-bar: "npm:^2.4.3"
     next-plugin-yaml: "npm:^1.0.1"
     next-unused: "npm:^0.0.6"
     node-cron: "npm:^3.0.3"
-    nodemailer: "npm:^8.0.4"
+    nodemailer: "npm:8.0.5"
     nodemon: "npm:^3.1.0"
     openapi-fetch: "npm:^0.14.0"
     openapi-react-query: "npm:^0.5.0"
@@ -9059,6 +9059,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 
@@ -10174,7 +10181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.34.4":
+"sharp@npm:^0.34.5":
   version: 0.34.5
   resolution: "sharp@npm:0.34.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8090,7 +8090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:8.0.5":
+"nodemailer@npm:^8.0.5":
   version: 8.0.5
   resolution: "nodemailer@npm:8.0.5"
   checksum: 10c0/5e8450499bd059c56d74ba96fa5f9928de2ecdae0d53c083dba5661d797114c1f9524d30f992d0263cc5a7dcf5a54b9c1d92dc1f766da150c9d0bde7d3798431
@@ -8310,7 +8310,7 @@ __metadata:
     next-plugin-yaml: "npm:^1.0.1"
     next-unused: "npm:^0.0.6"
     node-cron: "npm:^3.0.3"
-    nodemailer: "npm:8.0.5"
+    nodemailer: "npm:^8.0.5"
     nodemon: "npm:^3.1.0"
     openapi-fetch: "npm:^0.14.0"
     openapi-react-query: "npm:^0.5.0"


### PR DESCRIPTION
## Summary
- Upgraded **axios** 1.13.5 -> 1.15.0 (CRITICAL: SSRF via NO_PROXY bypass)
- Upgraded **next** 16.1.7 -> 16.2.3 (HIGH: DoS with Server Components)
- Upgraded **nodemailer** 8.0.4 -> 8.0.5 (MEDIUM: SMTP Command Injection)
- Added **basic-ftp** 5.2.2 resolution (HIGH: CRLF Injection + FTP Command Injection)

## Type Fixes Required by Next.js 16.2.3
Next.js 16.2.3 enforces `moduleResolution: "bundler"` in tsconfig.json, which exposed several pre-existing type issues:
- Added `src/axios.d.ts` to properly type the custom `ignoreGlobalErrorSnack` config property on the axios instance
- Fixed `AxiosGlobalErrorHandler.tsx`: interceptor `eject()` calls were missing required interceptor IDs, and `config.url` was accessed without null checks
- Widened mutation result types in `CustomNetworkSelectionStep` and `CopySnapshotModal` to accept `any` return type instead of `void`

## Remaining Issues
- No remaining security vulnerabilities. The `yarn npm audit` only reports deprecation warnings for transitive dependencies (eslint v8, glob v7, rimraf v3, etc.) which are not security issues.

## Verification
- [x] `yarn npm audit` shows no new security vulnerabilities
- [x] `yarn build` passes successfully
- [x] TypeScript type checking passes with `moduleResolution: "bundler"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)