### PR TITLE
fix(ci): force-push HAR updates instead of rebasing

### DIFF
--- a/.github/workflows/playwright-recorder.yml
+++ b/.github/workflows/playwright-recorder.yml
@@ -180,13 +180,7 @@ jobs:
           git commit -m "chore: update HAR files (${DATE})
 
         Test result: ${{ steps.playwright.outcome }}"
-          git fetch origin master
-          if ! git rebase origin/master; then
-            echo "Failed to rebase HAR updates onto the latest remote master branch"
-            git rebase --abort 2>/dev/null || true
-            exit 1
-          fi
-          git push origin HEAD:refs/heads/master
+          git push origin HEAD:refs/heads/master --force
         fi
 
     - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
## Summary

- The Playwright HAR Recorder workflow was failing during the push step with binary merge conflicts when `master` of the HAR sub-repo (`customer-portal-har-files`) had moved forward during the test run.
- `.har.gz` files are binary, so `git rebase origin/master` cannot auto-merge them — the job aborted with "Failed to rebase HAR updates onto the latest remote master branch".
- Replaced the `fetch + rebase + push` sequence with `git push --force`, matching the working pattern already used by `omnistrate-cloud-ui`'s recorder. This is safe because this workflow is the sole writer to the HAR repo.

## Test plan

- [ ] Trigger `Playwright HAR Recorder` via `workflow_dispatch` and confirm the push step succeeds even when the HAR repo's master has moved forward.
- [ ] Confirm the next scheduled (weekday 2:00 AM UTC) run completes end-to-end.