### PR TITLE
fix: resolve dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.11",
-    "dompurify": "3.3.3",
+    "dompurify": "3.4.0",
     "dotenv": "^16.4.5",
     "dotted-map": "^2.2.3",
     "ejs": "^3.1.10",
@@ -104,7 +104,7 @@
     "next-unused": "^0.0.6",
     "nodemon": "^3.1.0",
     "openapi-typescript": "^7.8.0",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.10",
     "prettier": "^3.1.0",
     "puppeteer": "^24.3.1",
     "tailwindcss": "^3.4.17",
@@ -114,7 +114,11 @@
   },
   "resolutions": {
     "axios": "1.15.0",
-    "basic-ftp": "5.2.2"
+    "basic-ftp": "5.3.0",
+    "dompurify": "3.4.0",
+    "follow-redirects": "1.16.0",
+    "postcss": "^8.5.10",
+    "uuid": "14.0.0"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3961,10 +3961,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:5.2.2":
-  version: 5.2.2
-  resolution: "basic-ftp@npm:5.2.2"
-  checksum: 10c0/a314a05450cf6311035d1bbb23c1ba1c8c0b991e7cb9bfafafc72a82bfafc540561c22eb046a58374688b7b9df502aa002fc28f4d366eb40964f307d131e06a6
+"basic-ftp@npm:5.3.0":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: 10c0/307ebc0635d06e671729d348e45e6eaec5f926713f93de535b268e17ae675942cd6903a84196cece948b54e04b24591431be3df79b2824551a0d5ed150555fb2
   languageName: node
   linkType: hard
 
@@ -5169,15 +5169,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.3.3, dompurify@npm:^3.3.0, dompurify@npm:^3.3.2":
-  version: 3.3.3
-  resolution: "dompurify@npm:3.3.3"
+"dompurify@npm:3.4.0":
+  version: 3.4.0
+  resolution: "dompurify@npm:3.4.0"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
+  checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
   languageName: node
   linkType: hard
 
@@ -6334,13 +6334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -8376,7 +8376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -8855,7 +8855,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     date-fns: "npm:^2.29.3"
     dayjs: "npm:^1.11.11"
-    dompurify: "npm:3.3.3"
+    dompurify: "npm:3.4.0"
     dotenv: "npm:^16.4.5"
     dotted-map: "npm:^2.2.3"
     ejs: "npm:^3.1.10"
@@ -8883,7 +8883,7 @@ __metadata:
     openapi-fetch: "npm:^0.14.0"
     openapi-react-query: "npm:^0.5.0"
     openapi-typescript: "npm:^7.8.0"
-    postcss: "npm:^8.4.49"
+    postcss: "npm:^8.5.10"
     prettier: "npm:^3.1.0"
     prop-types: "npm:^15.6.0"
     psl: "npm:^1.15.0"
@@ -9242,7 +9242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -9411,25 +9411,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.1.7, postcss@npm:^8.4.47, postcss@npm:^8.4.49":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+"postcss@npm:^8.5.10":
+  version: 8.5.13
+  resolution: "postcss@npm:8.5.13"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  checksum: 10c0/3aa7c8cbdfbfd99b34406a433cef56d164dd135fc9cb9e63d487cc363291f877a55ec7b8ff6ec15348c17c2d98a43be46bfad671e6340403041a3e79f70c2f2f
   languageName: node
   linkType: hard
 
@@ -11000,7 +10989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
@@ -12300,12 +12289,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixed 8 open Dependabot security alerts (1 high, 7 moderate)
- Bumped direct deps (`dompurify`, `postcss`) and added/updated yarn `resolutions` for transitive deps (`basic-ftp`, `follow-redirects`, `uuid`)
- Preserved pinned-without-caret format for `axios` and `next` per project convention; `dompurify` direct version remains pinned without caret

## Vulnerabilities Addressed
| # | Package | Severity | Fix |
|---|---------|----------|-----|
| 138 | basic-ftp | high | resolution `5.2.2` -> `5.3.0` (DoS via unbounded memory in `Client.list()`) |
| 146 | postcss | moderate | direct `^8.4.49` -> `^8.5.10` + resolution `^8.5.10` (XSS via unescaped `</style>`) |
| 145 | uuid | moderate | added resolution `14.0.0` (missing buffer bounds check in v3/v5/v6) |
| 143 | dompurify | moderate | direct `3.3.3` -> `3.4.0` + resolution `3.4.0` (SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode) |
| 142 | dompurify | moderate | same upgrade (FORBID_TAGS bypassed by function-based ADD_TAGS predicate) |
| 140 | dompurify | moderate | same upgrade (Prototype Pollution to XSS via CUSTOM_ELEMENT_HANDLING fallback) |
| 137 | dompurify | moderate | same upgrade (ADD_TAGS function form bypasses FORBID_TAGS) |
| 135 | follow-redirects | moderate | added resolution `1.16.0` (auth header leak on cross-domain redirect) |

## Remaining Issues
None. The remaining `yarn npm audit` entries are all deprecation warnings (eslint v8, glob v3, rimraf v3, inflight, prebuild-install, etc.) — not security CVEs and not flagged by Dependabot.

## Verification
- [x] `yarn install` succeeds and lockfile updated
- [x] `yarn npm audit --all --recursive --severity high` reports no audit suggestions
- [x] All 8 targeted Dependabot CVE entries no longer appear in audit output
- [x] `yarn build` passes (Compiled successfully)
- [x] Pinned-without-caret format preserved for `axios`, `next`, `dompurify`