### PR TITLE
fix: Resolve Dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tanstack/react-query": "^5.77.1",
     "@tanstack/react-table": "^8.20.5",
     "ansi-to-react": "^6.1.6",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "buffer": "^6.0.3",
     "clipboardy": "^3.0.0",
     "clsx": "^2.1.1",
@@ -111,10 +111,11 @@
     "wait-on": "^9.0.4"
   },
   "resolutions": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "basic-ftp": "5.3.0",
     "dompurify": "3.4.0",
     "follow-redirects": "1.16.0",
+    "ip-address": "^10.1.1",
     "postcss": "^8.5.10",
     "uuid": "14.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,14 +3802,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 
@@ -7124,10 +7124,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "ip-address@npm:10.0.1"
-  checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 
@@ -8849,7 +8849,7 @@ __metadata:
     "@types/react-google-recaptcha": "npm:^2.1.9"
     ansi-to-react: "npm:^6.1.6"
     autoprefixer: "npm:^10.4.20"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     buffer: "npm:^6.0.3"
     clipboardy: "npm:^3.0.0"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## Summary

Resolves 14 open Dependabot security alerts by upgrading two packages.

### Vulnerabilities addressed

**axios: 1.15.0 -> 1.15.2** (alerts #147-#159, 13 advisories)
- HIGH: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking
- HIGH: Header Injection via Prototype Pollution
- HIGH: Incomplete Fix for CVE-2025-62718 - NO_PROXY Bypassed via 127.0.0.0/8
- HIGH: Prototype pollution read-side gadgets in HTTP adapter (credential injection / request hijacking)
- MEDIUM: CRLF Injection in multipart/form-data via unsanitized blob.type
- MEDIUM: no_proxy bypass via IP alias allows SSRF
- MEDIUM: Unbounded recursion in toFormData causes DoS
- MEDIUM: HTTP adapter-streamed uploads bypass maxBodyLength when maxRedirects: 0
- MEDIUM: HTTP adapter streamed responses bypass maxContentLength
- MEDIUM: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget
- MEDIUM: Authentication Bypass via Prototype Pollution Gadget in validateStatus
- MEDIUM: Invisible JSON Response Tampering via Prototype Pollution Gadget in parseReviver
- LOW: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams

Updated both the direct dependency and the `resolutions` entry. Existing pin (no caret) is preserved.

**ip-address: 10.0.1 -> 10.2.0** (alert #160)
- MEDIUM: XSS in Address6 HTML-emitting methods (patched in 10.1.1)

This is a transitive dependency (pulled in via `socks` -> `puppeteer`). Added `"ip-address": "^10.1.1"` to `resolutions` to force a patched version.

## Remaining issues

None of the open Dependabot security alerts remain after this PR. Other items returned by `yarn npm audit` are deprecation notices (e.g., `rimraf`, `glob`, `inflight`, `eslint`, `@humanwhocodes/*`), not security advisories from Dependabot.

## Test plan

- [x] `yarn install` succeeds without immutable failures
- [x] `yarn build` passes
- [x] `yarn npm audit --all --recursive` shows no remaining `axios` or `ip-address` issues
- [x] `package.json` axios pin format preserved (no caret added)
- [ ] CI checks pass on this branch