### PR TITLE
fix: Resolve Dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "generate-password": "^1.7.1",
     "isomorphic-dompurify": "^2.23.0",
     "js-base64": "^3.7.5",
-    "js-cookie": "^3.0.1",
+    "js-cookie": "^3.0.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
     "monaco-editor": "^0.52.0",
@@ -112,6 +112,7 @@
   },
   "resolutions": {
     "basic-ftp": "^5.3.1",
+    "brace-expansion@^5.0.5": "^5.0.6",
     "postcss": "^8.5.10",
     "uuid": "14.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,12 +4052,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -7661,10 +7661,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^3.0.1":
-  version: 3.0.5
-  resolution: "js-cookie@npm:3.0.5"
-  checksum: 10c0/04a0e560407b4489daac3a63e231d35f4e86f78bff9d792011391b49c59f721b513411cd75714c418049c8dc9750b20fcddad1ca5a2ca616c3aca4874cce5b3a
+"js-cookie@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "js-cookie@npm:3.0.7"
+  checksum: 10c0/c921c43014e98bb94a1765663a1a10d693048d61444e374c1ecf459eba92320381f9c406e724df9aa44e819c4b606e6a7240f2abe2d5c54ad1e73a3002b191c2
   languageName: node
   linkType: hard
 
@@ -8892,7 +8892,7 @@ __metadata:
     generate-password: "npm:^1.7.1"
     isomorphic-dompurify: "npm:^2.23.0"
     js-base64: "npm:^3.7.5"
-    js-cookie: "npm:^3.0.1"
+    js-cookie: "npm:^3.0.7"
     jwt-decode: "npm:^4.0.0"
     lodash: "npm:^4.18.1"
     monaco-editor: "npm:^0.52.0"


### PR DESCRIPTION
## Summary

Resolves open Dependabot security alerts.

## Vulnerabilities Addressed

| # | Package | Severity | Fix |
|---|---------|----------|-----|
| 197 | js-cookie | high | Direct dep upgraded `^3.0.1` -> `^3.0.7` (GHSA prototype hijack / cookie attribute injection) |
| 196 | brace-expansion | medium | Transitive (via minimatch@10.2.5) pinned to `^5.0.6` via resolutions (DoS via large numeric range) |

## Remaining Issues

`yarn npm audit --all --recursive --severity high` reports no remaining high/critical issues. Moderate-severity deprecation notices remain (e.g. `inflight`, `whatwg-encoding`, `ws` inside `jsdom` via dev deps) but no Dependabot alerts are currently open for them.

## Verification

- [x] `yarn install` completes
- [x] `yarn npm audit --all --recursive --severity high` returns no audit suggestions
- [x] `yarn build` succeeds
- [x] Pinned packages (axios, next, uuid) retain their pinned versions; caret prefixes preserved elsewhere