### PR TITLE
fix: update flyctl-actions SHA to v1.6

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup flyctl
         timeout-minutes: 5
-        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be  # v1.5
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
 
       - name: Deploy to Fly
         timeout-minutes: 30


### PR DESCRIPTION
## Summary
- The pinned v1.5 SHA `fc53c09e1bc3be6f54706524e3b82c4f462f77be` was removed from upstream `superfly/flyctl-actions`, breaking Deploy to Fly with `archive could not be downloaded`.
- Bumps the action to the current `1.6` tag SHA `ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1` (verified downloadable from codeload).

## Test plan
- [ ] Re-run the Deploy to Fly workflow on dev and confirm the Setup flyctl step succeeds.