### PR TITLE
Rename customer-facing on-prem deployment copy to air-gapped

### DIFF
--- a/app/(dashboard)/instance-snapshots/components/CreateSnapshotDialogContent.tsx
+++ b/app/(dashboard)/instance-snapshots/components/CreateSnapshotDialogContent.tsx
@@ -64,7 +64,7 @@ const CreateSnapshotDialogContent: React.FC<CreateSnapshotDialogContentProps> = 
               ),
               disabled: isDisabled || installer,
               disabledMessage: installer
-                ? "Snapshots are not applicable for on-prem deployment instances"
+                ? "Snapshots are not applicable for air-gapped deployment instances"
                 : isDisabled
                   ? "Cannot create snapshot for Deleting or Deploying instances"
                   : "",

--- a/app/(dashboard)/instances/components/InstancesTableHeader.tsx
+++ b/app/(dashboard)/instances/components/InstancesTableHeader.tsx
@@ -133,7 +133,7 @@ const InstancesTableHeader: React.FC<InstancesTableHeaderProps> = ({
       disabledMessage: !selectedInstance
         ? "Please select an instance"
         : installer
-          ? "Not applicable for on-prem deployment instances"
+          ? "Not applicable for air-gapped deployment instances"
           : status === "DISCONNECTED"
             ? "Instance is disconnected"
             : status !== "RUNNING"
@@ -167,7 +167,7 @@ const InstancesTableHeader: React.FC<InstancesTableHeaderProps> = ({
       disabledMessage: !selectedInstance
         ? "Please select an instance"
         : installer
-          ? "Not applicable for on-prem deployment instances"
+          ? "Not applicable for air-gapped deployment instances"
           : status === "DISCONNECTED"
             ? "Instance is disconnected"
             : status !== "STOPPED"


### PR DESCRIPTION
## Summary
Customer-portal side of the AirGapped deployment-target rename (provider side: omnistrate-cloud-ui#3722).

Updates three customer-facing disabled-action messages so they say **"air-gapped deployment instances"** instead of **"on-prem deployment instances"**:
- Instances table Start/Stop actions (`InstancesTableHeader.tsx`)
- Create-snapshot dialog (`CreateSnapshotDialogContent.tsx`)

## Scope / deliberately left alone
- Pure copy change. **No logic changed.** The `OMNISTRATE_HOSTED` handling (`hideDashboardEndpoint`) and all `serviceModelType === "ON_PREM"` checks (cloud-provider derivation, health status, sidebar, installer flow) are untouched.
- Auto-generated `src/types/schema.ts` API docs are not modified.

## Test plan
- [ ] On an installer/air-gapped instance, the Start/Stop buttons' disabled tooltip reads "Not applicable for air-gapped deployment instances"
- [ ] Create-snapshot dialog disabled message reads "Snapshots are not applicable for air-gapped deployment instances"