### PR TITLE
Support subscription admin RBAC

### DIFF
--- a/app/(dashboard)/access-control/components/InviteUsersCard.tsx
+++ b/app/(dashboard)/access-control/components/InviteUsersCard.tsx
@@ -138,6 +138,10 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
     [consumptionSubscriptionAdminRBAC]
   );
   const validationSchema = useMemo(() => getInviteUsersValidationSchema(roleOptions), [roleOptions]);
+  const serviceMenuItems = useMemo(
+    () => getServiceMenuItems(subscriptions, consumptionSubscriptionAdminRBAC),
+    [subscriptions, consumptionSubscriptionAdminRBAC]
+  );
 
   const createUserInvitesMutation = useMutation({
     mutationFn: async (data: InviteUsersFormValues) => {
@@ -156,7 +160,9 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
               consumptionSubscriptionAdminRBAC
             );
             if (!subscription?.id) {
-              throw new Error("No manageable subscription found for invite");
+              // Return a rejected promise (instead of throwing synchronously) so the
+              // remaining invites in the batch still start; Promise.all still rejects overall.
+              return Promise.reject(new Error("No manageable subscription found for invite"));
             }
 
             return inviteSubscriptionUser(subscription.id, payload);
@@ -231,8 +237,6 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                   return (
                     <>
                       {values.userInvite.map((invite, index) => {
-                        const serviceMenuItems = getServiceMenuItems(subscriptions, consumptionSubscriptionAdminRBAC);
-
                         const servicePlanMenuItems = getServicePlanMenuItems(
                           subscriptions,
                           values.userInvite[index].serviceId,

--- a/app/(dashboard)/access-control/components/InviteUsersCard.tsx
+++ b/app/(dashboard)/access-control/components/InviteUsersCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { Add } from "@mui/icons-material";
 import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
 import { InputAdornment } from "@mui/material";
@@ -9,10 +10,17 @@ import { cn } from "lib/utils";
 
 import { inviteSubscriptionUser } from "src/api/users";
 import FieldError from "src/components/FormElementsv2/FieldError/FieldError";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
 import { colors } from "src/themeConfig";
 import { Subscription } from "src/types/subscription";
+import {
+  getHighestPermissionSubscription,
+  getSubscriptionUserInviteRoleOptions,
+  isManageableSubscriptionRole,
+  toSubscriptionUserRoleType,
+} from "src/utils/consumptionSubscriptionAdminRBAC";
 import Button from "components/Button/Button";
 import LoadingSpinnerSmall from "components/CircularProgress/CircularProgress";
 import Form from "components/FormElementsv2/Form/Form";
@@ -23,7 +31,7 @@ import DataGridHeaderTitle from "components/Headers/DataGridHeaderTitle";
 import DeleteIcon from "components/Icons/Delete/Delete";
 import { Text } from "components/Typography/Typography";
 
-import { inviteUsersValidationSchema } from "../utils";
+import { getInviteUsersValidationSchema } from "../utils";
 
 const getNewEnvVariable = () => {
   return {
@@ -34,11 +42,11 @@ const getNewEnvVariable = () => {
   };
 };
 
-const getServiceMenuItems = (subscriptions: Subscription[]) => {
+const getServiceMenuItems = (subscriptions: Subscription[], consumptionSubscriptionAdminRBAC: boolean) => {
   const serviceIdSet = new Set();
 
   const serviceMenuItems = subscriptions
-    .filter((sub) => sub.roleType === "root")
+    .filter((sub) => isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC))
     .map((sub) => {
       if (!serviceIdSet.has(sub.serviceId)) {
         serviceIdSet.add(sub.serviceId);
@@ -61,17 +69,49 @@ const getServiceMenuItems = (subscriptions: Subscription[]) => {
   );
 };
 
-const getServicePlanMenuItems = (subscriptions: Subscription[], serviceId: string) => {
+const getServicePlanMenuItems = (
+  subscriptions: Subscription[],
+  serviceId: string,
+  consumptionSubscriptionAdminRBAC: boolean
+) => {
+  const servicePlanIdSet = new Set();
+
   const servicePlanMenuItems = subscriptions
-    ?.filter((sub) => sub.serviceId === serviceId && sub.roleType === "root")
+    ?.filter(
+      (sub) =>
+        sub.serviceId === serviceId && isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC)
+    )
     .map((sub) => {
+      if (servicePlanIdSet.has(sub.productTierId)) {
+        return null;
+      }
+      servicePlanIdSet.add(sub.productTierId);
       return {
         label: sub.productTierName,
         value: sub.productTierId,
       };
     })
+    .filter((item) => item !== null)
+    // @ts-ignore
     .sort((a, b) => a.label.localeCompare(b.label));
   return servicePlanMenuItems;
+};
+
+const getManageableSubscriptionForInvite = (
+  subscriptions: Subscription[],
+  serviceId: string,
+  servicePlanId: string,
+  consumptionSubscriptionAdminRBAC: boolean
+) => {
+  return getHighestPermissionSubscription(
+    subscriptions.filter(
+      (sub) =>
+        sub.serviceId === serviceId &&
+        sub.productTierId === servicePlanId &&
+        isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC)
+    ),
+    consumptionSubscriptionAdminRBAC
+  );
 };
 
 type InviteUsersCardProps = {
@@ -94,6 +134,12 @@ interface InviteUsersFormValues {
 const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetchingUsers }) => {
   const snackbar = useSnackbar();
   const { subscriptions, isSubscriptionsPending } = useGlobalData();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
+  const roleOptions = useMemo(
+    () => getSubscriptionUserInviteRoleOptions(consumptionSubscriptionAdminRBAC),
+    [consumptionSubscriptionAdminRBAC]
+  );
+  const validationSchema = useMemo(() => getInviteUsersValidationSchema(roleOptions), [roleOptions]);
 
   const createUserInvitesMutation = useMutation({
     mutationFn: async (data: any) => {
@@ -105,10 +151,13 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
               roleType: d.roleType,
             };
 
-            const rootSubscription = subscriptions.find(
-              (sub) => sub.serviceId === d.serviceId && sub.productTierId === d.servicePlanId && sub.roleType === "root"
+            const subscription = getManageableSubscriptionForInvite(
+              subscriptions,
+              d.serviceId,
+              d.servicePlanId,
+              consumptionSubscriptionAdminRBAC
             );
-            return inviteSubscriptionUser(rootSubscription?.id, payload);
+            return inviteSubscriptionUser(subscription?.id, payload);
           })
         );
         snackbar.showSuccess("Invites Sent");
@@ -137,16 +186,15 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
       const valuesToBeSubmitted = structuredClone(values);
 
       for (let i = 0; i < valuesToBeSubmitted?.userInvite?.length; i++) {
-        if (valuesToBeSubmitted.userInvite[i]["roleType"] === "Editor") {
-          valuesToBeSubmitted.userInvite[i]["roleType"] = "editor";
-        }
-        if (valuesToBeSubmitted.userInvite[i]["roleType"] === "Reader") {
-          valuesToBeSubmitted.userInvite[i]["roleType"] = "reader";
+        if (valuesToBeSubmitted.userInvite[i]["roleType"]) {
+          valuesToBeSubmitted.userInvite[i]["roleType"] = toSubscriptionUserRoleType(
+            valuesToBeSubmitted.userInvite[i]["roleType"]
+          );
         }
       }
       createUserInvitesMutation.mutate(valuesToBeSubmitted);
     },
-    validationSchema: inviteUsersValidationSchema,
+    validationSchema,
   });
 
   const { values, handleChange, handleBlur, setFieldValue } = formData;
@@ -181,11 +229,12 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                   return (
                     <>
                       {values.userInvite.map((invite, index) => {
-                        const serivceMenuItems = getServiceMenuItems(subscriptions);
+                        const serivceMenuItems = getServiceMenuItems(subscriptions, consumptionSubscriptionAdminRBAC);
 
                         const servicePlanMenuItems = getServicePlanMenuItems(
                           subscriptions,
-                          values.userInvite[index].serviceId
+                          values.userInvite[index].serviceId,
+                          consumptionSubscriptionAdminRBAC
                         );
 
                         return (
@@ -233,6 +282,7 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                                 onChange={(e) => {
                                   handleChange(e);
                                   setFieldValue(`userInvite[${index}].servicePlanId`, "");
+                                  setFieldValue(`userInvite[${index}].roleType`, "");
                                 }}
                                 sx={{ mt: 0 }}
                                 displayEmpty
@@ -250,7 +300,11 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                                   ))
                                 ) : (
                                   <MenuItem value="" disabled>
-                                    <i>No Products With Root Access</i>
+                                    <i>
+                                      {consumptionSubscriptionAdminRBAC
+                                        ? "No Products With Member Management Access"
+                                        : "No Products With Root Access"}
+                                    </i>
                                   </MenuItem>
                                 )}
                               </Select>
@@ -268,7 +322,10 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                                 name={`userInvite[${index}].servicePlanId`}
                                 value={invite.servicePlanId}
                                 onBlur={handleBlur}
-                                onChange={handleChange}
+                                onChange={(e) => {
+                                  handleChange(e);
+                                  setFieldValue(`userInvite[${index}].roleType`, "");
+                                }}
                                 disabled={createUserInvitesMutation.isPending || isFetchingUsers}
                                 sx={{ mt: 0 }}
                                 displayEmpty
@@ -312,7 +369,7 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                                 }}
                                 maxWidth="400px"
                               >
-                                {["Editor", "Reader"].map((option) => (
+                                {roleOptions.map((option) => (
                                   <MenuItem key={option} value={option}>
                                     {option}
                                   </MenuItem>

--- a/app/(dashboard)/access-control/components/InviteUsersCard.tsx
+++ b/app/(dashboard)/access-control/components/InviteUsersCard.tsx
@@ -42,8 +42,15 @@ const getNewEnvVariable = () => {
   };
 };
 
+type SelectMenuItem = {
+  label: string;
+  value: string;
+};
+
+const isSelectMenuItem = (item: SelectMenuItem | null): item is SelectMenuItem => item !== null;
+
 const getServiceMenuItems = (subscriptions: Subscription[], consumptionSubscriptionAdminRBAC: boolean) => {
-  const serviceIdSet = new Set();
+  const serviceIdSet = new Set<string>();
 
   const serviceMenuItems = subscriptions
     .filter((sub) => isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC))
@@ -58,15 +65,7 @@ const getServiceMenuItems = (subscriptions: Subscription[], consumptionSubscript
       return null;
     });
 
-  return (
-    serviceMenuItems
-      .filter((item) => item !== null)
-      // @ts-ignore
-      .sort((a, b) => a?.label.localeCompare(b?.label)) as {
-      label: string;
-      value: string;
-    }[]
-  );
+  return serviceMenuItems.filter(isSelectMenuItem).sort((a, b) => a.label.localeCompare(b.label));
 };
 
 const getServicePlanMenuItems = (
@@ -74,10 +73,10 @@ const getServicePlanMenuItems = (
   serviceId: string,
   consumptionSubscriptionAdminRBAC: boolean
 ) => {
-  const servicePlanIdSet = new Set();
+  const servicePlanIdSet = new Set<string>();
 
   const servicePlanMenuItems = subscriptions
-    ?.filter(
+    .filter(
       (sub) =>
         sub.serviceId === serviceId && isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC)
     )
@@ -91,8 +90,7 @@ const getServicePlanMenuItems = (
         value: sub.productTierId,
       };
     })
-    .filter((item) => item !== null)
-    // @ts-ignore
+    .filter(isSelectMenuItem)
     .sort((a, b) => a.label.localeCompare(b.label));
   return servicePlanMenuItems;
 };
@@ -142,7 +140,7 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
   const validationSchema = useMemo(() => getInviteUsersValidationSchema(roleOptions), [roleOptions]);
 
   const createUserInvitesMutation = useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: InviteUsersFormValues) => {
       try {
         await Promise.all(
           data.userInvite.map((d) => {
@@ -157,7 +155,11 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
               d.servicePlanId,
               consumptionSubscriptionAdminRBAC
             );
-            return inviteSubscriptionUser(subscription?.id, payload);
+            if (!subscription?.id) {
+              throw new Error("No manageable subscription found for invite");
+            }
+
+            return inviteSubscriptionUser(subscription.id, payload);
           })
         );
         snackbar.showSuccess("Invites Sent");
@@ -229,7 +231,7 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                   return (
                     <>
                       {values.userInvite.map((invite, index) => {
-                        const serivceMenuItems = getServiceMenuItems(subscriptions, consumptionSubscriptionAdminRBAC);
+                        const serviceMenuItems = getServiceMenuItems(subscriptions, consumptionSubscriptionAdminRBAC);
 
                         const servicePlanMenuItems = getServicePlanMenuItems(
                           subscriptions,
@@ -288,12 +290,12 @@ const InviteUsersCard: React.FC<InviteUsersCardProps> = ({ refetchUsers, isFetch
                                 displayEmpty
                                 renderValue={(value) => {
                                   if (!value) return "Product";
-                                  return serivceMenuItems.find((item) => item.value === value)?.label;
+                                  return serviceMenuItems.find((item) => item.value === value)?.label;
                                 }}
                                 maxWidth="400px"
                               >
-                                {serivceMenuItems?.length > 0 ? (
-                                  serivceMenuItems.map((option) => (
+                                {serviceMenuItems?.length > 0 ? (
+                                  serviceMenuItems.map((option) => (
                                     <MenuItem key={option.value} value={option.value}>
                                       {option.label}
                                     </MenuItem>

--- a/app/(dashboard)/access-control/page.tsx
+++ b/app/(dashboard)/access-control/page.tsx
@@ -3,10 +3,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { createColumnHelper } from "@tanstack/react-table";
+import { useSelector } from "react-redux";
 
 import { $api } from "src/api/query";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
+import { selectUserrootData } from "src/slices/userDataSlice";
 import { SubscriptionUser } from "src/types/consumptionUser";
 import {
   getEnumFromUserRoleString,
@@ -43,6 +46,8 @@ const AccessControlPage = () => {
   const [isOverlayOpen, setIsOverlayOpen] = useState<boolean>(false);
   const [selectedUser, setSelectedUser] = useState<SubscriptionUser | null>(null);
   const { subscriptions, isSubscriptionsPending } = useGlobalData();
+  const currentUser = useSelector(selectUserrootData);
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   useEffect(() => {
     if (searchUserId) {
@@ -140,8 +145,20 @@ const AccessControlPage = () => {
           const isDeleteAllowed = isOperationAllowedByRBAC(
             operationEnum.UnInvite,
             getEnumFromUserRoleString(subscription?.roleType),
-            viewEnum.Access_AccessControl
+            viewEnum.Access_AccessControl,
+            {
+              consumptionSubscriptionAdminRBAC,
+            }
           );
+          const isSubscriptionOwner = data.row.original.roleType === "root";
+          const isCurrentAdmin =
+            consumptionSubscriptionAdminRBAC &&
+            data.row.original.roleType === "admin" &&
+            data.row.original.userId === currentUser?.id;
+
+          if (isCurrentAdmin) {
+            return null;
+          }
 
           return (
             <Button
@@ -152,18 +169,18 @@ const AccessControlPage = () => {
                 setOverlayType("delete-dialog");
                 setSelectedUser(data.row.original);
               }}
-              startIcon={<DeleteIcon color="#B42318" disabled={data.row.original.roleType === "root"} />}
+              startIcon={<DeleteIcon color="#B42318" disabled={isSubscriptionOwner} />}
               sx={{
                 border: "none !important",
                 padding: "4px !important",
                 boxShadow: "none !important",
               }}
               disableRipple
-              disabled={data.row.original.roleType === "root" || !isDeleteAllowed}
+              disabled={isSubscriptionOwner || !isDeleteAllowed}
               disabledMessage={
                 !isDeleteAllowed
                   ? "You do not have permission to remove access of this user"
-                  : data.row.original.roleType === "root"
+                  : isSubscriptionOwner
                     ? "Cannot remove access of the subscription owner"
                     : ""
               }
@@ -177,7 +194,7 @@ const AccessControlPage = () => {
         },
       }),
     ];
-  }, [subscriptionsObj]);
+  }, [consumptionSubscriptionAdminRBAC, currentUser?.id, subscriptionsObj]);
 
   const deleteUserMutation = $api.useMutation(
     "delete",

--- a/app/(dashboard)/access-control/utils.ts
+++ b/app/(dashboard)/access-control/utils.ts
@@ -16,5 +16,3 @@ export const getInviteUsersValidationSchema = (roleOptions = getSubscriptionUser
       )
       .min(1, "At least one user invite is required"),
   });
-
-export const inviteUsersValidationSchema = getInviteUsersValidationSchema();

--- a/app/(dashboard)/access-control/utils.ts
+++ b/app/(dashboard)/access-control/utils.ts
@@ -1,15 +1,20 @@
 import * as yup from "yup";
 
-export const inviteUsersValidationSchema = yup.object().shape({
-  userInvite: yup
-    .array()
-    .of(
-      yup.object().shape({
-        email: yup.string().required("Email is required").email("Please enter a valid email address").trim(),
-        roleType: yup.string().required("Role is required").oneOf(["Editor", "Reader"], "Please select a valid role"),
-        serviceId: yup.string().required("Service is required"),
-        servicePlanId: yup.string().required("Subscription plan is required"),
-      })
-    )
-    .min(1, "At least one user invite is required"),
-});
+import { getSubscriptionUserInviteRoleOptions } from "src/utils/consumptionSubscriptionAdminRBAC";
+
+export const getInviteUsersValidationSchema = (roleOptions = getSubscriptionUserInviteRoleOptions()) =>
+  yup.object().shape({
+    userInvite: yup
+      .array()
+      .of(
+        yup.object().shape({
+          email: yup.string().required("Email is required").email("Please enter a valid email address").trim(),
+          roleType: yup.string().required("Role is required").oneOf(roleOptions, "Please select a valid role"),
+          serviceId: yup.string().required("Service is required"),
+          servicePlanId: yup.string().required("Subscription plan is required"),
+        })
+      )
+      .min(1, "At least one user invite is required"),
+  });
+
+export const inviteUsersValidationSchema = getInviteUsersValidationSchema();

--- a/app/(dashboard)/cloud-accounts/components/CloudAccountForm.tsx
+++ b/app/(dashboard)/cloud-accounts/components/CloudAccountForm.tsx
@@ -1,21 +1,19 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import CloudProviderRadio from "app/(dashboard)/components/CloudProviderRadio/CloudProviderRadio";
 import SubscriptionMenu from "app/(dashboard)/components/SubscriptionMenu/SubscriptionMenu";
 import SubscriptionPlanRadio from "app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio";
 import { getServiceMenuItems } from "app/(dashboard)/instances/utils";
 import { useFormik } from "formik";
-import { useMemo } from "react";
 import { useSelector } from "react-redux";
 
-import GridDynamicForm from "components/DynamicForm/GridDynamicForm";
-import { FormConfiguration } from "components/DynamicForm/types";
-import LoadingSpinner from "components/LoadingSpinner/LoadingSpinner";
 import { $api } from "src/api/query";
 import { getResourceInstanceDetails } from "src/api/resourceInstance";
 import { CLOUD_PROVIDERS, cloudProviderLongLogoMap } from "src/constants/cloudProviders";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
 import { selectUserrootData } from "src/slices/userDataSlice";
@@ -24,6 +22,9 @@ import { ServiceOffering } from "src/types/serviceOffering";
 import { getAwsBootstrapArn, getGcpServiceEmail } from "src/utils/accountConfig/accountConfig";
 import { CLOUD_PROVIDER_DEFAULT_CREATION_METHOD } from "src/utils/constants/accountConfig";
 import { getResultParams } from "src/utils/instance";
+import GridDynamicForm from "components/DynamicForm/GridDynamicForm";
+import { FormConfiguration } from "components/DynamicForm/types";
+import LoadingSpinner from "components/LoadingSpinner/LoadingSpinner";
 
 import { CloudAccountValidationSchema } from "../constants";
 import { getInitialValues, getValidSubscriptionForInstanceCreation } from "../utils";
@@ -54,6 +55,7 @@ const CloudAccountForm = ({
     subscriptionsObj,
     isSubscriptionsPending,
   } = useGlobalData();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const allInstances: ResourceInstance[] = instances;
   //subscriptionID -> key, number of instances -> value
@@ -227,7 +229,8 @@ const CloudAccountForm = ({
       byoaSubscriptions,
       byoaServiceOfferingsObj,
       byoaServiceOfferings,
-      allInstances
+      allInstances,
+      consumptionSubscriptionAdminRBAC
     ),
     enableReinitialize: true,
     validationSchema: CloudAccountValidationSchema,
@@ -348,7 +351,9 @@ const CloudAccountForm = ({
                   byoaServiceOfferingsObj,
                   byoaSubscriptions,
                   allInstances,
-                  serviceId
+                  serviceId,
+                  undefined,
+                  consumptionSubscriptionAdminRBAC
                 );
 
                 const servicePlanId = subscription?.productTierId || "";
@@ -399,7 +404,8 @@ const CloudAccountForm = ({
                       byoaSubscriptions,
                       allInstances,
                       serviceId,
-                      servicePlanId
+                      servicePlanId,
+                      consumptionSubscriptionAdminRBAC
                     );
 
                     setFieldValue("subscriptionId", subscriptionId || subscription?.id || "");
@@ -575,7 +581,7 @@ const CloudAccountForm = ({
         },
       ],
     };
-  }, [formMode, subscriptions, byoaServiceOfferings, values]);
+  }, [consumptionSubscriptionAdminRBAC, formMode, subscriptions, byoaServiceOfferings, values]);
 
   if (isFetchingServiceOfferings) {
     return <LoadingSpinner />;

--- a/app/(dashboard)/cloud-accounts/utils.ts
+++ b/app/(dashboard)/cloud-accounts/utils.ts
@@ -2,6 +2,11 @@ import { ResourceInstance } from "src/types/resourceInstance";
 import { ServiceOffering } from "src/types/serviceOffering";
 import { Subscription } from "src/types/subscription";
 import { CLOUD_PROVIDER_DEFAULT_CREATION_METHOD } from "src/utils/constants/accountConfig";
+import {
+  getHighestPermissionSubscription,
+  isManageableSubscriptionRole,
+  isSubscriptionWriteRole,
+} from "src/utils/consumptionSubscriptionAdminRBAC";
 import { getResultParams } from "src/utils/instance";
 
 export type CloudAccountFormValues = {
@@ -26,7 +31,8 @@ export const getValidSubscriptionForInstanceCreation = (
   subscriptions: Subscription[],
   instances: ResourceInstance[],
   serviceId?: string,
-  servicePlanId?: string
+  servicePlanId?: string,
+  consumptionSubscriptionAdminRBAC = false
 ): Subscription | undefined => {
   // Build subscription instance count hash
   const subscriptionInstancesNumHash: Record<string, number> = {};
@@ -35,9 +41,11 @@ export const getValidSubscriptionForInstanceCreation = (
     subscriptionInstancesNumHash[subId] = (subscriptionInstancesNumHash[subId] || 0) + 1;
   });
 
-  // Filter subscriptions to editor/root roles and valid service offerings
+  // Filter subscriptions to write-capable roles and valid service offerings
   let filteredSubscriptions = subscriptions.filter(
-    (sub) => serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] && ["root", "editor"].includes(sub.roleType)
+    (sub) =>
+      serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] &&
+      isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
   );
 
   // Filter by serviceID if provided
@@ -73,18 +81,9 @@ export const getValidSubscriptionForInstanceCreation = (
     return !!hasValidPayment;
   };
 
-  // First try to find a valid root subscription
-  const rootSubscriptions = sortedSubscriptions.filter((sub) => sub.roleType === "root");
-  const validRootSubscription = rootSubscriptions.find((sub) => isSubscriptionValid(sub));
+  const validSubscriptions = sortedSubscriptions.filter((sub) => isSubscriptionValid(sub, true));
 
-  if (validRootSubscription) {
-    return validRootSubscription;
-  }
-
-  // If no valid root subscription, try editor subscriptions
-  // Note: Editor subscriptions always check quota
-  const editorSubscriptions = sortedSubscriptions.filter((sub) => sub.roleType === "editor");
-  return editorSubscriptions.find((sub) => isSubscriptionValid(sub, true));
+  return getHighestPermissionSubscription(validSubscriptions, consumptionSubscriptionAdminRBAC);
 };
 
 export const getInitialValues = (
@@ -97,7 +96,8 @@ export const getInitialValues = (
   byoaSubscriptions: Subscription[],
   byoaServiceOfferingsObj: Record<string, Record<string, ServiceOffering>>,
   byoaServiceOfferings: ServiceOffering[],
-  instances: ResourceInstance[]
+  instances: ResourceInstance[],
+  consumptionSubscriptionAdminRBAC = false
 ): CloudAccountFormValues => {
   if (selectedInstance) {
     const subscription = byoaSubscriptions.find((sub) => sub.id === selectedInstance.subscriptionId);
@@ -139,7 +139,7 @@ export const getInitialValues = (
         sub.serviceId === initialFormValues?.serviceId &&
         sub.productTierId === initialFormValues?.servicePlanId &&
         sub.id === initialFormValues?.subscriptionId &&
-        sub.roleType === "root"
+        isManageableSubscriptionRole(sub.roleType, consumptionSubscriptionAdminRBAC)
     )
   );
 
@@ -173,7 +173,8 @@ export const getInitialValues = (
     byoaSubscriptions,
     instances,
     "",
-    ""
+    "",
+    consumptionSubscriptionAdminRBAC
   );
 
   const serviceId =

--- a/app/(dashboard)/components/SubscriptionMenu/SubscriptionMenu.tsx
+++ b/app/(dashboard)/components/SubscriptionMenu/SubscriptionMenu.tsx
@@ -6,8 +6,10 @@ import Select from "src/components/FormElementsv2/Select/Select";
 import SubscriptionTypeDirectIcon from "src/components/Icons/SubscriptionType/SubscriptionTypeDirectIcon";
 import SubscriptionTypeInvitedIcon from "src/components/Icons/SubscriptionType/SubscriptionTypeInvitedIcon";
 import { Text } from "src/components/Typography/Typography";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
 import { Subscription } from "src/types/subscription";
+import { isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 import { getBillingRoute } from "src/utils/routes";
 
 type SubscriptionMenuProps = {
@@ -25,6 +27,7 @@ const SubscriptionMenu: React.FC<SubscriptionMenuProps> = ({
 }) => {
   const { values, touched, errors, handleChange, handleBlur } = formData;
   const { serviceOfferingsObj } = useGlobalData();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   return (
     <Select
@@ -55,7 +58,9 @@ const SubscriptionMenu: React.FC<SubscriptionMenuProps> = ({
             !(subscription.allowCreatesWhenPaymentNotConfigured ?? plan.allowCreatesWhenPaymentNotConfigured);
 
           const isDisabled =
-            !["editor", "root"].includes(subscription.roleType) || isInstanceLimitReached || hasPaymentIssue;
+            !isSubscriptionWriteRole(subscription.roleType, consumptionSubscriptionAdminRBAC) ||
+            isInstanceLimitReached ||
+            hasPaymentIssue;
 
           let disabledMessage: string | React.ReactNode = "";
           if (subscription.roleType === "reader") {

--- a/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
+++ b/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
@@ -169,7 +169,6 @@ const SubscriptionPlanRadio: React.FC<SubscriptionPlanRadioProps> = ({
   const environmentType = useEnvironmentType();
   const snackbar = useSnackbar();
   const queryClient = useQueryClient();
-  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const { subscriptions, subscriptionRequests, serviceOfferingsObj } = useGlobalData();
 

--- a/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
+++ b/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
@@ -13,12 +13,18 @@ import { getSubscriptionRequest } from "src/api/subscriptionRequests";
 import { getSubscription } from "src/api/subscriptions";
 import LoadingSpinnerSmall from "src/components/CircularProgress/CircularProgress";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
 import { colors } from "src/themeConfig";
 import { ServiceOffering } from "src/types/serviceOffering";
 import { Subscription } from "src/types/subscription";
 import { SubscriptionRequest } from "src/types/subscriptionRequest";
+import {
+  getHighestPermissionSubscription,
+  isManageableSubscriptionRole,
+  isSubscriptionWriteRole,
+} from "src/utils/consumptionSubscriptionAdminRBAC";
 import { getSubscriptionsRoute } from "src/utils/routes";
 import Button from "components/Button/Button";
 import CircleCheckIcon from "components/Icons/ServicePlanCard/CircleCheckIcon";
@@ -38,7 +44,13 @@ const SubscriptionPlanCard = ({
   disabledMessage,
   isPlanSelectionDisabled,
 }) => {
-  const rootSubscription = subscriptions.find((sub) => sub.roleType === "root");
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
+  const currentSubscription = getHighestPermissionSubscription(
+    subscriptions.filter((subscription) =>
+      isManageableSubscriptionRole(subscription.roleType, consumptionSubscriptionAdminRBAC)
+    ),
+    consumptionSubscriptionAdminRBAC
+  );
   const [isSubscribing, setIsSubscribing] = useState(false);
 
   const card = (
@@ -77,7 +89,7 @@ const SubscriptionPlanCard = ({
             Click here to view plan details <ArrowOutward />
           </Link>
         </div>
-        {!rootSubscription && !subscriptionRequest && (
+        {!currentSubscription && !subscriptionRequest && (
           <Button
             data-testid="subscribe-button"
             variant="contained"
@@ -99,7 +111,7 @@ const SubscriptionPlanCard = ({
           </Button>
         )}
 
-        {rootSubscription && (
+        {currentSubscription && (
           <Button
             variant="contained"
             disabled
@@ -112,7 +124,7 @@ const SubscriptionPlanCard = ({
           </Button>
         )}
 
-        {subscriptionRequest && !rootSubscription && (
+        {subscriptionRequest && !currentSubscription && (
           <Button
             variant="contained"
             disabled
@@ -163,6 +175,7 @@ const SubscriptionPlanRadio: React.FC<SubscriptionPlanRadioProps> = ({
   const environmentType = useEnvironmentType();
   const snackbar = useSnackbar();
   const queryClient = useQueryClient();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const { subscriptions, subscriptionRequests, serviceOfferingsObj } = useGlobalData();
 
@@ -202,7 +215,9 @@ const SubscriptionPlanRadio: React.FC<SubscriptionPlanRadioProps> = ({
                 key={plan.productTierID}
                 plan={plan}
                 subscriptions={subscriptions.filter(
-                  (sub) => sub.productTierId === plan.productTierID && ["root", "editor"].includes(sub.roleType)
+                  (sub) =>
+                    sub.productTierId === plan.productTierID &&
+                    isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
                 )}
                 subscriptionRequest={subscriptionRequestsObj[plan.productTierID]}
                 onSubscribeClick={async () => {

--- a/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
+++ b/app/(dashboard)/components/SubscriptionPlanRadio/SubscriptionPlanRadio.tsx
@@ -20,11 +20,7 @@ import { colors } from "src/themeConfig";
 import { ServiceOffering } from "src/types/serviceOffering";
 import { Subscription } from "src/types/subscription";
 import { SubscriptionRequest } from "src/types/subscriptionRequest";
-import {
-  getHighestPermissionSubscription,
-  isManageableSubscriptionRole,
-  isSubscriptionWriteRole,
-} from "src/utils/consumptionSubscriptionAdminRBAC";
+import { getHighestPermissionSubscription, isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 import { getSubscriptionsRoute } from "src/utils/routes";
 import Button from "components/Button/Button";
 import CircleCheckIcon from "components/Icons/ServicePlanCard/CircleCheckIcon";
@@ -45,11 +41,9 @@ const SubscriptionPlanCard = ({
   isPlanSelectionDisabled,
 }) => {
   const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
-  const currentSubscription = getHighestPermissionSubscription(
-    subscriptions.filter((subscription) =>
-      isManageableSubscriptionRole(subscription.roleType, consumptionSubscriptionAdminRBAC)
-    ),
-    consumptionSubscriptionAdminRBAC
+  const currentSubscription = getHighestPermissionSubscription(subscriptions, consumptionSubscriptionAdminRBAC);
+  const writeSubscriptions = subscriptions.filter((subscription) =>
+    isSubscriptionWriteRole(subscription.roleType, consumptionSubscriptionAdminRBAC)
   );
   const [isSubscribing, setIsSubscribing] = useState(false);
 
@@ -59,13 +53,13 @@ const SubscriptionPlanCard = ({
       className={clsx(
         "gap-3 px-4 pt-4 pb-3 rounded-xl outline outline-[2px]",
         isSelected ? "outline-success-500" : "outline-gray-300",
-        (!subscriptions.length || disabled || isPlanSelectionDisabled) && "bg-gray-50"
+        (!writeSubscriptions.length || disabled || isPlanSelectionDisabled) && "bg-gray-50"
       )}
       style={{
-        cursor: subscriptions.length && !isPlanSelectionDisabled ? "pointer" : "default",
+        cursor: writeSubscriptions.length && !isPlanSelectionDisabled ? "pointer" : "default",
       }}
       onClick={() => {
-        if (subscriptions.length && !isPlanSelectionDisabled) {
+        if (writeSubscriptions.length && !isPlanSelectionDisabled) {
           onClick();
         }
       }}
@@ -144,11 +138,11 @@ const SubscriptionPlanCard = ({
     return <Tooltip title={disabledMessage}>{card}</Tooltip>;
   }
 
-  if (!subscriptions.length && !subscriptionRequest) {
+  if (!writeSubscriptions.length && !currentSubscription && !subscriptionRequest) {
     return <Tooltip title="Subscribe to this plan before you can use it">{card}</Tooltip>;
   }
 
-  if (!subscriptions.length && subscriptionRequest) {
+  if (!writeSubscriptions.length && !currentSubscription && subscriptionRequest) {
     return <Tooltip title="Subscription request is pending approval">{card}</Tooltip>;
   }
 
@@ -214,11 +208,7 @@ const SubscriptionPlanRadio: React.FC<SubscriptionPlanRadioProps> = ({
               <SubscriptionPlanCard
                 key={plan.productTierID}
                 plan={plan}
-                subscriptions={subscriptions.filter(
-                  (sub) =>
-                    sub.productTierId === plan.productTierID &&
-                    isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
-                )}
+                subscriptions={subscriptions.filter((sub) => sub.productTierId === plan.productTierID)}
                 subscriptionRequest={subscriptionRequestsObj[plan.productTierID]}
                 onSubscribeClick={async () => {
                   try {

--- a/app/(dashboard)/custom-networks/components/CustomNetworkForm.tsx
+++ b/app/(dashboard)/custom-networks/components/CustomNetworkForm.tsx
@@ -1,17 +1,19 @@
 "use client";
 
+import { useMemo } from "react";
 import CloudProviderRadio from "app/(dashboard)/components/CloudProviderRadio/CloudProviderRadio";
 import { useFormik } from "formik";
-import { useMemo } from "react";
 
-import GridDynamicForm from "components/DynamicForm/GridDynamicForm";
-import { FormConfiguration } from "components/DynamicForm/types";
 import { $api } from "src/api/query";
 import Switch from "src/components/Switch/Switch";
 import Tooltip from "src/components/Tooltip/Tooltip";
 import { CLOUD_PROVIDERS, cloudProviderLongLogoMap } from "src/constants/cloudProviders";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
+import { isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
+import GridDynamicForm from "components/DynamicForm/GridDynamicForm";
+import { FormConfiguration } from "components/DynamicForm/types";
 
 import { CustomNetworkValidationSchema } from "../constants";
 
@@ -25,12 +27,17 @@ const CustomNetworkForm = ({
 }) => {
   const snackbar = useSnackbar();
   const { subscriptions, isFetchingSubscriptions } = useGlobalData();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const subscriptionOwners = useMemo(() => {
     const seen = new Set<string>();
     return subscriptions
       .filter(
-        (sub) => sub.status === "ACTIVE" && sub.rootUserOrgId && sub.roleType !== "reader" && sub.roleType !== "root"
+        (sub) =>
+          sub.status === "ACTIVE" &&
+          sub.rootUserOrgId &&
+          isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC) &&
+          sub.roleType !== "root"
       )
       .reduce<{ name: string; orgIdentifier: string; orgId: string }[]>((acc, sub) => {
         const orgId = sub.rootUserOrgId!;
@@ -44,7 +51,7 @@ const CustomNetworkForm = ({
         }
         return acc;
       }, []);
-  }, [subscriptions]);
+  }, [consumptionSubscriptionAdminRBAC, subscriptions]);
 
   const createCustomNetworkMutation = $api.useMutation("post", "/2022-09-01-00/resource-instance/custom-network", {
     onSuccess: () => {

--- a/app/(dashboard)/custom-networks/components/CustomNetworksTableHeader.tsx
+++ b/app/(dashboard)/custom-networks/components/CustomNetworksTableHeader.tsx
@@ -5,9 +5,11 @@ import Button from "src/components/Button/Button";
 import SearchInput from "src/components/DataGrid/SearchInput";
 import DataGridHeaderTitle from "src/components/Headers/DataGridHeaderTitle";
 import RefreshWithToolTip from "src/components/RefreshWithTooltip/RefreshWithToolTip";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import { selectUserrootData } from "src/slices/userDataSlice";
 import { CustomNetwork } from "src/types/customNetwork";
 import { Subscription } from "src/types/subscription";
+import { isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 
 const CustomNetworksTableHeader = ({
   count,
@@ -37,6 +39,7 @@ const CustomNetworksTableHeader = ({
   subscriptions?: Subscription[];
 }) => {
   const currentUser = useSelector(selectUserrootData);
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   /**
    * Determines whether the currently selected network's actions should be blocked
@@ -46,13 +49,8 @@ const CustomNetworksTableHeader = ({
    * - Exactly one row is selected
    * - The selected network has an `owningUserId`
    * - The logged-in user is NOT the owner
-   * - The logged-in user does NOT have an "editor" or "root" role on any subscription
-   *   whose `rootUserOrgId` matches the network's `owningUserId`
-   *
-   * @remarks
-   * ⚠️ Potential bug: `rootUserOrgId` is an Org ID while `owningUserId` is a User ID.
-   * These two values represent different entity types and are unlikely to ever be equal,
-   * meaning the `hasAccess` check may always evaluate to `false`.
+   * - The logged-in user does NOT have write-capable access on any subscription
+   *   whose owner matches the network's `owningUserId`
    */
   const isOwnershipBlocked = useMemo(() => {
     if (selectedRows.length !== 1) return false;
@@ -65,13 +63,14 @@ const CustomNetworksTableHeader = ({
     // If the logged-in user is the owner, allow
     if (networkOwnerId === currentUser?.id) return false;
 
-    // Check if the user has editor or root role on any subscription belonging to the network owner's org
+    // Check if the user has write access on any subscription belonging to the network owner's org
     const hasAccess = subscriptions.some(
-      (sub) => sub.rootUserId === networkOwnerId && (sub.roleType === "editor" || sub.roleType === "root")
+      (sub) =>
+        sub.rootUserId === networkOwnerId && isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
     );
 
     return !hasAccess;
-  }, [selectedRows, customNetworks, currentUser?.id, subscriptions]);
+  }, [consumptionSubscriptionAdminRBAC, selectedRows, customNetworks, currentUser?.id, subscriptions]);
 
   const getModifyDeleteDisabledMessage = () => {
     if (selectedRows.length !== 1) return "Please select a customer network";

--- a/app/(dashboard)/custom-networks/hooks/useSubscriptionOwners.ts
+++ b/app/(dashboard)/custom-networks/hooks/useSubscriptionOwners.ts
@@ -2,9 +2,12 @@ import { useMemo } from "react";
 
 import { $api } from "src/api/query";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
+import { isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 
 const useSubscriptionOwners = () => {
   const environmentType = useEnvironmentType();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const query = $api.useQuery("get", "/2022-09-01-00/subscription", {
     params: {
@@ -19,7 +22,12 @@ const useSubscriptionOwners = () => {
 
     const seen = new Set<string>();
     return query.data.subscriptions
-      .filter((sub) => sub.status === "ACTIVE" && sub.rootUserOrgId && sub.roleType !== "reader")
+      .filter(
+        (sub) =>
+          sub.status === "ACTIVE" &&
+          sub.rootUserOrgId &&
+          isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
+      )
       .reduce<{ name: string; email: string; orgId: string }[]>((acc, sub) => {
         const orgId = sub.rootUserOrgId!;
         if (!seen.has(orgId)) {
@@ -32,7 +40,7 @@ const useSubscriptionOwners = () => {
         }
         return acc;
       }, []);
-  }, [query.data]);
+  }, [consumptionSubscriptionAdminRBAC, query.data]);
 
   return { ...query, data: subscriptionOwners };
 };

--- a/app/(dashboard)/instances/components/InstanceForm.tsx
+++ b/app/(dashboard)/instances/components/InstanceForm.tsx
@@ -1,23 +1,16 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import useCustomNetworks from "app/(dashboard)/custom-networks/hooks/useCustomNetworks";
 import { useFormik } from "formik";
 import _, { cloneDeep } from "lodash";
-import { useEffect, useMemo, useState } from "react";
 import type { StringSchema } from "yup";
 import * as yup from "yup";
 
-import Button from "components/Button/Button";
-import CardWithTitle from "components/Card/CardWithTitle";
-import LoadingSpinnerSmall from "components/CircularProgress/CircularProgress";
-import GridDynamicField from "components/DynamicForm/GridDynamicField";
-import PreviewCard from "components/DynamicForm/PreviewCard";
-import Form from "components/FormElementsv2/Form/Form";
-import LoadingSpinner from "components/LoadingSpinner/LoadingSpinner";
-import { Text } from "components/Typography/Typography";
 import { $api } from "src/api/query";
 import { productTierTypes } from "src/constants/servicePlan";
 import useAvailabilityZone from "src/hooks/query/useAvailabilityZone";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useResourcesInstanceIds from "src/hooks/useResourcesInstanceIds";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
@@ -27,6 +20,14 @@ import { ResourceInstance } from "src/types/resourceInstance";
 import { APIEntity } from "src/types/serviceOffering";
 import { isCloudAccountInstance } from "src/utils/access/byoaResource";
 import { checkBYOADeploymentInstance, getResultParams } from "src/utils/instance";
+import Button from "components/Button/Button";
+import CardWithTitle from "components/Card/CardWithTitle";
+import LoadingSpinnerSmall from "components/CircularProgress/CircularProgress";
+import GridDynamicField from "components/DynamicForm/GridDynamicField";
+import PreviewCard from "components/DynamicForm/PreviewCard";
+import Form from "components/FormElementsv2/Form/Form";
+import LoadingSpinner from "components/LoadingSpinner/LoadingSpinner";
+import { Text } from "components/Typography/Typography";
 
 import { REQUEST_PARAMS_FIELDS_TO_FILTER } from "../constants";
 import useCustomerVersionSets from "../hooks/useCustomerVersionSets";
@@ -83,6 +84,7 @@ const InstanceForm = ({
     subscriptionsObj,
     isFetchingSubscriptions,
   } = useGlobalData();
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
 
   const nonCloudAccountInstances = useMemo(() => {
     return instances.filter((instance) => !isCloudAccountInstance(instance));
@@ -177,11 +179,12 @@ const InstanceForm = ({
         serviceOfferingsObj,
         serviceOfferings,
         nonCloudAccountInstances,
-        [] // Will be updated later when customerVersionSets loads
+        [], // Will be updated later when customerVersionSets loads
+        consumptionSubscriptionAdminRBAC
       ),
     // Only recompute when the selected instance changes (modify mode) or on first mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedInstance?.id]
+    [consumptionSubscriptionAdminRBAC, selectedInstance?.id]
   );
 
   const formData = useFormik({
@@ -929,7 +932,8 @@ const InstanceForm = ({
       customerVersionSets,
       isFetchingVersionSets,
       isFetchingResourceInstanceIds,
-      cloudAccountInstances
+      cloudAccountInstances,
+      consumptionSubscriptionAdminRBAC
     );
   }, [
     formMode,
@@ -942,6 +946,7 @@ const InstanceForm = ({
     isFetchingVersionSets,
     cloudAccountInstances,
     isFetchingResourceInstanceIds,
+    consumptionSubscriptionAdminRBAC,
   ]);
 
   const networkConfigurationFields = useMemo(() => {

--- a/app/(dashboard)/instances/components/InstanceFormFields.tsx
+++ b/app/(dashboard)/instances/components/InstanceFormFields.tsx
@@ -1,5 +1,5 @@
-import SubscriptionMenu from "app/(dashboard)/components/SubscriptionMenu/SubscriptionMenu";
 import Link from "next/link";
+import SubscriptionMenu from "app/(dashboard)/components/SubscriptionMenu/SubscriptionMenu";
 
 import { Field } from "src/components/DynamicForm/types";
 import StatusChip from "src/components/StatusChip/StatusChip";
@@ -58,7 +58,8 @@ export const getStandardInformationFields = (
   versionSets: TierVersionSet[],
   isFetchingVersionSets: boolean,
   isFetchingResourceInstanceIds: boolean,
-  cloudAccountInstances: CloudAccountInstanceOption[]
+  cloudAccountInstances: CloudAccountInstanceOption[],
+  consumptionSubscriptionAdminRBAC = false
 ) => {
   if (isFetchingServiceOfferings) return [];
 
@@ -167,7 +168,9 @@ export const getStandardInformationFields = (
           serviceOfferingsObj,
           subscriptions,
           instances,
-          serviceId
+          serviceId,
+          undefined,
+          consumptionSubscriptionAdminRBAC
         );
 
         const servicePlanId = subscription?.productTierId || "";
@@ -285,7 +288,8 @@ export const getStandardInformationFields = (
               subscriptions,
               instances,
               serviceId,
-              servicePlanId
+              servicePlanId,
+              consumptionSubscriptionAdminRBAC
             );
 
             setFieldValue("subscriptionId", subscriptionId || subscription?.id || "");

--- a/app/(dashboard)/instances/utils.ts
+++ b/app/(dashboard)/instances/utils.ts
@@ -19,6 +19,7 @@ import {
   ResourceInstanceNetworkTopology,
 } from "src/types/resourceInstance";
 import { TierVersionSet } from "src/types/tier-version-set";
+import { getHighestPermissionSubscription, isSubscriptionWriteRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 import { getResultParams } from "src/utils/instance";
 
 import { loadStatusLabel, loadStatusMap } from "./constants";
@@ -290,7 +291,8 @@ export const getValidSubscriptionForInstanceCreation = (
   subscriptions: Subscription[],
   instances: ResourceInstance[],
   serviceId?: string,
-  servicePlanId?: string
+  servicePlanId?: string,
+  consumptionSubscriptionAdminRBAC = false
 ): Subscription | undefined => {
   // Build subscription instance count hash
   const subscriptionInstancesNumHash: Record<string, number> = {};
@@ -299,9 +301,11 @@ export const getValidSubscriptionForInstanceCreation = (
     subscriptionInstancesNumHash[subId] = (subscriptionInstancesNumHash[subId] || 0) + 1;
   });
 
-  // Filter subscriptions to editor/root roles and valid service offerings
+  // Filter subscriptions to write-capable roles and valid service offerings
   let filteredSubscriptions = subscriptions.filter(
-    (sub) => serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] && ["root", "editor"].includes(sub.roleType)
+    (sub) =>
+      serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] &&
+      isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
   );
 
   // Filter by serviceID if provided
@@ -318,22 +322,11 @@ export const getValidSubscriptionForInstanceCreation = (
   // Sort by service name
   const sortedSubscriptions = filteredSubscriptions.sort((a, b) => a.serviceName.localeCompare(b.serviceName));
 
-  // First try to find a valid root subscription
-  const rootSubscriptions = sortedSubscriptions.filter((sub) => sub.roleType === "root");
-  const validRootSubscription = rootSubscriptions.find((el) =>
+  const validSubscriptions = sortedSubscriptions.filter((el) =>
     isSubscriptionValid(el, serviceOfferingsObj, subscriptionInstancesNumHash)
   );
 
-  if (validRootSubscription) {
-    return validRootSubscription;
-  }
-
-  // If no valid root subscription, try editor subscriptions
-  const editorSubscriptions = sortedSubscriptions.filter((sub) => sub.roleType === "editor");
-  return (
-    editorSubscriptions.find((el) => isSubscriptionValid(el, serviceOfferingsObj, subscriptionInstancesNumHash)) ||
-    undefined
-  );
+  return getHighestPermissionSubscription(validSubscriptions, consumptionSubscriptionAdminRBAC);
 };
 
 export const cloudProviderToPlatformMap: Record<string, string> = {
@@ -358,7 +351,8 @@ export const getInitialValues = (
   serviceOfferingsObj: Record<string, Record<string, ServiceOffering>>,
   serviceOfferings: ServiceOffering[],
   instances: ResourceInstance[],
-  versionSets?: TierVersionSet[]
+  versionSets?: TierVersionSet[],
+  consumptionSubscriptionAdminRBAC = false
 ) => {
   if (instance) {
     const subscription = subscriptions.find((sub) => sub.id === instance?.subscriptionId);
@@ -401,7 +395,9 @@ export const getInitialValues = (
   }
 
   const filteredSubscriptions = subscriptions.filter(
-    (sub) => serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] && ["root", "editor"].includes(sub.roleType)
+    (sub) =>
+      serviceOfferingsObj[sub.serviceId]?.[sub.productTierId] &&
+      isSubscriptionWriteRole(sub.roleType, consumptionSubscriptionAdminRBAC)
   );
 
   const sortedSubscriptionsByName = filteredSubscriptions.sort((a, b) => a.serviceName.localeCompare(b.serviceName));
@@ -411,7 +407,10 @@ export const getInitialValues = (
   const selectedSubscription: Subscription | undefined = getValidSubscriptionForInstanceCreation(
     serviceOfferingsObj,
     subscriptions,
-    instances
+    instances,
+    undefined,
+    undefined,
+    consumptionSubscriptionAdminRBAC
   );
 
   const serviceId =

--- a/app/(dashboard)/subscriptions/components/ManageSubscriptionsForm.tsx
+++ b/app/(dashboard)/subscriptions/components/ManageSubscriptionsForm.tsx
@@ -7,10 +7,15 @@ import { useSelector } from "react-redux";
 import { $api } from "src/api/query";
 import { deleteSubscription } from "src/api/subscriptions";
 import useEnvironmentType from "src/hooks/useEnvironmentType";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import useSnackbar from "src/hooks/useSnackbar";
 import { useGlobalData } from "src/providers/GlobalDataProvider";
 import { selectUserrootData } from "src/slices/userDataSlice";
 import { Subscription } from "src/types/subscription";
+import {
+  getHighestPermissionSubscription,
+  isManageableSubscriptionRole,
+} from "src/utils/consumptionSubscriptionAdminRBAC";
 import CardWithTitle from "components/Card/CardWithTitle";
 import FieldDescription from "components/FormElementsv2/FieldDescription/FieldDescription";
 import FieldTitle from "components/FormElementsv2/FieldTitle/FieldTitle";
@@ -35,6 +40,7 @@ const ManageSubscriptionsForm = ({ defaultServiceId, defaultServicePlanId, isFet
   const snackbar = useSnackbar();
   const queryClient = useQueryClient();
   const selectUser = useSelector(selectUserrootData);
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
   const [isUnsubscribeDialogOpen, setIsUnsubscribeDialogOpen] = useState(false);
   const [subscriptionIdToDelete, setSubscriptionIdToDelete] = useState<string | undefined>("");
 
@@ -66,13 +72,23 @@ const ManageSubscriptionsForm = ({ defaultServiceId, defaultServicePlanId, isFet
     defaultServicePlanId || services[0]?.productTierID || ""
   );
 
-  // Object of Root Subscriptions and Subscription Requests
+  // Object of manageable subscriptions and subscription requests
   const subscriptionsObj = useMemo(() => {
-    return subscriptions?.reduce((acc, subscription) => {
-      if (subscription.roleType === "root") acc[subscription.productTierId] = subscription;
+    const subscriptionsByProductTier = subscriptions?.reduce((acc, subscription) => {
+      if (isManageableSubscriptionRole(subscription.roleType, consumptionSubscriptionAdminRBAC)) {
+        acc[subscription.productTierId] = [...(acc[subscription.productTierId] || []), subscription];
+      }
       return acc;
     }, {});
-  }, [subscriptions]);
+
+    return Object.entries(subscriptionsByProductTier || {}).reduce((acc, [productTierId, subscriptions]) => {
+      acc[productTierId] = getHighestPermissionSubscription(
+        subscriptions as Subscription[],
+        consumptionSubscriptionAdminRBAC
+      );
+      return acc;
+    }, {});
+  }, [consumptionSubscriptionAdminRBAC, subscriptions]);
 
   const subscriptionRequestsObj = useMemo(() => {
     return subscriptionRequests

--- a/app/(dashboard)/subscriptions/components/SubscriptionsTableHeader.tsx
+++ b/app/(dashboard)/subscriptions/components/SubscriptionsTableHeader.tsx
@@ -1,4 +1,6 @@
 import RefreshWithToolTip from "src/components/RefreshWithTooltip/RefreshWithToolTip";
+import useFeatureFlags from "src/hooks/useFeatureFlags";
+import { isManageableSubscriptionRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 import Button from "components/Button/Button";
 import SearchInput from "components/DataGrid/SearchInput";
 import DataGridHeaderTitle from "components/Headers/DataGridHeaderTitle";
@@ -15,6 +17,8 @@ const SubscriptionsTableHeader = ({
   refetchSubscriptions,
   selectedSubscription,
 }) => {
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
+
   return (
     <div className="py-5 px-6 flex items-center justify-between gap-8">
       <DataGridHeaderTitle
@@ -43,15 +47,18 @@ const SubscriptionsTableHeader = ({
             selectedSubscription?.defaultSubscription || // Cannot Unsubscribe From Default Subscription
             isUnsubscribing ||
             isFetchingSubscriptions ||
-            selectedSubscription?.roleType !== "root"
+            !isManageableSubscriptionRole(selectedSubscription?.roleType, consumptionSubscriptionAdminRBAC)
           }
           disabledMessage={
             selectedRows.length !== 1
               ? "Please select a subscription to unsubscribe"
               : selectedSubscription?.defaultSubscription
                 ? "Cannot unsubscribe from Default subscription"
-                : selectedSubscription && selectedSubscription?.roleType !== "root"
-                  ? "Cannot unsubscribe without Root access"
+                : selectedSubscription &&
+                    !isManageableSubscriptionRole(selectedSubscription?.roleType, consumptionSubscriptionAdminRBAC)
+                  ? consumptionSubscriptionAdminRBAC
+                    ? "Cannot unsubscribe without Root or Admin access"
+                    : "Cannot unsubscribe without Root access"
                   : ""
           }
         >

--- a/src/components/ServicePlanCard/ServicePlanCard.tsx
+++ b/src/components/ServicePlanCard/ServicePlanCard.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import Image from "next/image";
 import { Box } from "@mui/material";
 
+import useFeatureFlags from "src/hooks/useFeatureFlags";
 import { colors } from "src/themeConfig";
 import { SetState } from "src/types/common/reactGenerics";
 import { Subscription } from "src/types/subscription";
 import { SubscriptionRequest } from "src/types/subscriptionRequest";
+import { isManageableSubscriptionRole } from "src/utils/consumptionSubscriptionAdminRBAC";
 
 import Button from "../Button/Button";
 import CircleCheckIcon from "../Icons/ServicePlanCard/CircleCheckIcon";
@@ -37,7 +39,10 @@ const ServicePlanCard: React.FC<ServicePlanCardProps> = ({
   onUnsubscribeClick,
 }) => {
   const isAutoApprove = servicePlan.AutoApproveSubscription;
-  const isUnsubscribeAllowed = !rootSubscription?.defaultSubscription && rootSubscription?.roleType === "root";
+  const { consumptionSubscriptionAdminRBAC } = useFeatureFlags();
+  const isUnsubscribeAllowed =
+    !rootSubscription?.defaultSubscription &&
+    isManageableSubscriptionRole(rootSubscription?.roleType, consumptionSubscriptionAdminRBAC);
   const [isSubscribing, setIsSubscribing] = useState(false);
 
   return (
@@ -147,8 +152,11 @@ const ServicePlanCard: React.FC<ServicePlanCardProps> = ({
           disabledMessage={
             rootSubscription?.defaultSubscription
               ? "Cannot unsubscribe from Default subscription"
-              : rootSubscription && rootSubscription?.roleType !== "root"
-                ? "Cannot unsubscribe without Root access"
+              : rootSubscription &&
+                  !isManageableSubscriptionRole(rootSubscription?.roleType, consumptionSubscriptionAdminRBAC)
+                ? consumptionSubscriptionAdminRBAC
+                  ? "Cannot unsubscribe without Root or Admin access"
+                  : "Cannot unsubscribe without Root access"
                 : ""
           }
         >

--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,15 @@
+import { useProviderOrgDetails } from "src/providers/ProviderOrgDetailsProvider";
+
+const featureFlagNames = {
+  consumptionSubscriptionAdminRBAC: "CONSUMPTION_SUBSCRIPTION_ADMIN_RBAC",
+} as const;
+
+const useFeatureFlags = () => {
+  const { featureFlags } = useProviderOrgDetails();
+
+  return {
+    consumptionSubscriptionAdminRBAC: Boolean(featureFlags?.[featureFlagNames.consumptionSubscriptionAdminRBAC]),
+  };
+};
+
+export default useFeatureFlags;

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -3,4 +3,8 @@ import type { paths } from "./schema";
 export type DescribeUserSuccessResponse =
   paths["/2022-09-01-00/user"]["get"]["responses"]["200"]["content"]["application/json"];
 
-export type ProviderUser = DescribeUserSuccessResponse;
+export type FeatureFlags = Record<string, boolean | undefined>;
+
+export type ProviderUser = DescribeUserSuccessResponse & {
+  featureFlags?: FeatureFlags;
+};

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,10 +1,4 @@
 import type { paths } from "./schema";
 
-export type DescribeUserSuccessResponse =
+export type ProviderUser =
   paths["/2022-09-01-00/user"]["get"]["responses"]["200"]["content"]["application/json"];
-
-export type FeatureFlags = Record<string, boolean | undefined>;
-
-export type ProviderUser = DescribeUserSuccessResponse & {
-  featureFlags?: FeatureFlags;
-};

--- a/src/utils/access/findSubscription.js
+++ b/src/utils/access/findSubscription.js
@@ -6,7 +6,7 @@ const ROLE_TYPES = {
 };
 
 // If a user has multiple subscriptions this function finds the subscription by priority.
-// Priority order is default subscription, root, admin, editor, then reader.
+// Priority order is default subscription, root, admin when admin RBAC is enabled, editor, then reader.
 
 export const findSubscriptionByPriority = (
   subscriptions,

--- a/src/utils/access/findSubscription.js
+++ b/src/utils/access/findSubscription.js
@@ -1,16 +1,19 @@
 const ROLE_TYPES = {
   ROOT: "root",
+  ADMIN: "admin",
   EDITOR: "editor",
   READER: "reader",
 };
 
-//If a user has multiple subscriptions this function finds the subscriptions by priority.Priority roder is as follows
-//first find default subscription
-//else find subscription root role
-//else find subscription with editor role
-//else find subscription with reader role
+// If a user has multiple subscriptions this function finds the subscription by priority.
+// Priority order is default subscription, root, admin, editor, then reader.
 
-export const findSubscriptionByPriority = (subscriptions, serviceId, productTierId) => {
+export const findSubscriptionByPriority = (
+  subscriptions,
+  serviceId,
+  productTierId,
+  consumptionSubscriptionAdminRBAC = false
+) => {
   if (!subscriptions || !subscriptions?.length) {
     return null;
   }
@@ -31,6 +34,13 @@ export const findSubscriptionByPriority = (subscriptions, serviceId, productTier
   const rootSubscription = filteredList?.find((item) => item?.roleType === ROLE_TYPES.ROOT);
   if (rootSubscription) {
     return rootSubscription;
+  }
+
+  if (consumptionSubscriptionAdminRBAC) {
+    const adminSubscription = filteredList?.find((item) => item?.roleType === ROLE_TYPES.ADMIN);
+    if (adminSubscription) {
+      return adminSubscription;
+    }
   }
 
   const editorSubscription = filteredList?.find((item) => item?.roleType === ROLE_TYPES.EDITOR);

--- a/src/utils/consumptionSubscriptionAdminRBAC.ts
+++ b/src/utils/consumptionSubscriptionAdminRBAC.ts
@@ -34,7 +34,11 @@ export const getSubscriptionRolePriority = (roleType?: string, consumptionSubscr
 export const getHighestPermissionSubscription = <T extends Pick<Subscription, "roleType" | "serviceName">>(
   subscriptions: T[],
   consumptionSubscriptionAdminRBAC = false
-) => {
+): T | undefined => {
+  if (!subscriptions.length) {
+    return undefined;
+  }
+
   return [...subscriptions].sort((a, b) => {
     const priorityDiff =
       getSubscriptionRolePriority(b.roleType, consumptionSubscriptionAdminRBAC) -

--- a/src/utils/consumptionSubscriptionAdminRBAC.ts
+++ b/src/utils/consumptionSubscriptionAdminRBAC.ts
@@ -16,7 +16,7 @@ export const isSubscriptionWriteRole = (roleType?: string, consumptionSubscripti
   return roleType === "root" || roleType === "editor" || (consumptionSubscriptionAdminRBAC && roleType === "admin");
 };
 
-export const getSubscriptionRolePriority = (roleType?: string, consumptionSubscriptionAdminRBAC = false) => {
+const getSubscriptionRolePriority = (roleType?: string, consumptionSubscriptionAdminRBAC = false) => {
   switch (roleType) {
     case "root":
       return 4;

--- a/src/utils/consumptionSubscriptionAdminRBAC.ts
+++ b/src/utils/consumptionSubscriptionAdminRBAC.ts
@@ -1,0 +1,46 @@
+import type { Subscription } from "src/types/subscription";
+
+const subscriptionUserInviteRoleOptions = ["Editor", "Reader"];
+const subscriptionUserInviteRoleOptionsWithAdmin = ["Admin", "Editor", "Reader"];
+
+export const getSubscriptionUserInviteRoleOptions = (consumptionSubscriptionAdminRBAC = false) =>
+  consumptionSubscriptionAdminRBAC ? subscriptionUserInviteRoleOptionsWithAdmin : subscriptionUserInviteRoleOptions;
+
+export const toSubscriptionUserRoleType = (roleLabel: string) => roleLabel.toLowerCase();
+
+export const isManageableSubscriptionRole = (roleType?: string, consumptionSubscriptionAdminRBAC = false) => {
+  return roleType === "root" || (consumptionSubscriptionAdminRBAC && roleType === "admin");
+};
+
+export const isSubscriptionWriteRole = (roleType?: string, consumptionSubscriptionAdminRBAC = false) => {
+  return roleType === "root" || roleType === "editor" || (consumptionSubscriptionAdminRBAC && roleType === "admin");
+};
+
+export const getSubscriptionRolePriority = (roleType?: string, consumptionSubscriptionAdminRBAC = false) => {
+  switch (roleType) {
+    case "root":
+      return 4;
+    case "admin":
+      return consumptionSubscriptionAdminRBAC ? 3 : 0;
+    case "editor":
+      return 2;
+    case "reader":
+      return 1;
+    default:
+      return 0;
+  }
+};
+
+export const getHighestPermissionSubscription = <T extends Pick<Subscription, "roleType" | "serviceName">>(
+  subscriptions: T[],
+  consumptionSubscriptionAdminRBAC = false
+) => {
+  return [...subscriptions].sort((a, b) => {
+    const priorityDiff =
+      getSubscriptionRolePriority(b.roleType, consumptionSubscriptionAdminRBAC) -
+      getSubscriptionRolePriority(a.roleType, consumptionSubscriptionAdminRBAC);
+    if (priorityDiff !== 0) return priorityDiff;
+
+    return (a.serviceName || "").localeCompare(b.serviceName || "");
+  })[0];
+};

--- a/src/utils/isAllowedByRBAC.js
+++ b/src/utils/isAllowedByRBAC.js
@@ -35,7 +35,9 @@ const viewEnum = {
   Access_Resources: "Access_Resources",
 };
 
-function isOperationAllowedByRBAC(operation, role, view) {
+function isOperationAllowedByRBAC(operation, role, view, options = {}) {
+  const isConsumptionSubscriptionAdminRBACEnabled = Boolean(options.consumptionSubscriptionAdminRBAC);
+
   switch (true) {
     // Admin - BillingPricing
     case operation === operationEnum.Read && role === roleEnum.Admin && view === viewEnum.BillingPricing:
@@ -125,6 +127,16 @@ function isOperationAllowedByRBAC(operation, role, view) {
 
     // Access_AccessControl -  Admin
     case operation === operationEnum.List && role === roleEnum.Admin && view === viewEnum.Access_AccessControl:
+      return true;
+    case isConsumptionSubscriptionAdminRBACEnabled &&
+      operation === operationEnum.Invite &&
+      role === roleEnum.Admin &&
+      view === viewEnum.Access_AccessControl:
+      return true;
+    case isConsumptionSubscriptionAdminRBACEnabled &&
+      operation === operationEnum.UnInvite &&
+      role === roleEnum.Admin &&
+      view === viewEnum.Access_AccessControl:
       return true;
 
     // Access_Resources - Root

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "types": [
-      "node"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -19,31 +13,21 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
-      "src/*": [
-        "src/*"
-      ],
-      "components/*": [
-        "src/components/*"
-      ],
-      "hooks/*": [
-        "src/hooks/*"
-      ],
-      "utils/*": [
-        "src/utils/*"
-      ],
-      "public/*": [
-        "public/*"
-      ],
-      "lib/*": [
-        "lib/*"
-      ],
-      "@/components/*": [
-        "components/*"
-      ]
+      "src/*": ["./src/*"],
+      "components/*": ["./src/components/*"],
+      "hooks/*": ["./src/hooks/*"],
+      "utils/*": ["./src/utils/*"],
+      "public/*": ["./public/*"],
+      "lib/*": ["./lib/*"],
+      "app/*": ["./app/*"],
+      "constants/*": ["./constants/*"],
+      "page-objects/*": ["./page-objects/*"],
+      "test-fixtures/*": ["./test-fixtures/*"],
+      "test-utils/*": ["./test-utils/*"],
+      "@/components/*": ["./components/*"]
     },
-    "target": "es5",
+    "target": "ES2017",
     "forceConsistentCasingInFileNames": true,
     "plugins": [
       {
@@ -61,8 +45,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "scripts"
-  ]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the access control and user invitation flows, primarily by integrating feature flag-based role-based access control (RBAC) logic. The changes ensure that the UI and backend logic adapt dynamically based on the new `consumptionSubscriptionAdminRBAC` feature flag, enabling more granular permission management and a more flexible invite process.

**Access Control and RBAC Enhancements:**

* Updated the logic for determining which subscriptions and roles are manageable and invite-able by leveraging new utility functions (`isManageableSubscriptionRole`, `getHighestPermissionSubscription`, `getSubscriptionUserInviteRoleOptions`, `toSubscriptionUserRoleType`) that take into account the `consumptionSubscriptionAdminRBAC` feature flag. This affects how service and plan menus are filtered and displayed, as well as how invites are processed. [[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R13-R23) [[2]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L37-R49) [[3]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L64-R116) [[4]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L108-R160) [[5]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L184-R237) [[6]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L253-R307) [[7]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L315-R372)
* The invite user form now dynamically generates its validation schema and role options based on the enabled feature flag, allowing for different sets of valid roles depending on the RBAC mode. [[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L26-R34) [[2]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R137-R142) [[3]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L140-R197) [[4]](diffhunk://#diff-69d959a6360a9d99809cb364e412fbbf50c1e7de7c15922886e9e01de4e7e125L3-R20)
* The access control page and cloud account form both now read and use the `consumptionSubscriptionAdminRBAC` flag, ensuring consistent permission logic across the app. This includes preventing subscription admins from deleting themselves and updating UI labels/messages accordingly. [[1]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eR6-R12) [[2]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eR49-R50) [[3]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL143-R161) [[4]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL155-R183) [[5]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL180-R197) [[6]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR3-R16) [[7]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR58) [[8]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eL230-R233) [[9]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eL351-R356)

**User Experience Improvements:**

* The invite form resets the role selection when changing the service or plan, to prevent invalid role-plan combinations. [[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R285) [[2]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L271-R328)
* UI messages and disabled states for dropdowns and actions now accurately reflect the user's permissions under the current RBAC mode, improving clarity for end users. [[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L253-R307) [[2]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL155-R183)

**Code Quality and Consistency:**

* Refactored imports and utility usage for clarity and maintainability, ensuring all RBAC logic is centralized and easily adjustable for future changes. [[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R3) [[2]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR25-R27)

Overall, these changes make the access control and invitation flows more robust, maintainable, and adaptable to evolving permission requirements.

**References:**  
[[1]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R13-R23) [[2]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L37-R49) [[3]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L64-R116) [[4]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L108-R160) [[5]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L184-R237) [[6]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L253-R307) [[7]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L315-R372) [[8]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L26-R34) [[9]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R137-R142) [[10]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L140-R197) [[11]](diffhunk://#diff-69d959a6360a9d99809cb364e412fbbf50c1e7de7c15922886e9e01de4e7e125L3-R20) [[12]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eR6-R12) [[13]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eR49-R50) [[14]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL143-R161) [[15]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL155-R183) [[16]](diffhunk://#diff-1e237f6cb234d50e3325e0bb04faadd245df285300f75a38d015ad04ea5aef8eL180-R197) [[17]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR3-R16) [[18]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR58) [[19]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eL230-R233) [[20]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eL351-R356) [[21]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R285) [[22]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321L271-R328) [[23]](diffhunk://#diff-8d6cffe4dc25d40beb35a7b6f599455005d9ecca9cc341c38841341b2b73296eR25-R27) [[24]](diffhunk://#diff-77e98d7f46b3078053327a374c64cc65b88b9c6bdeed5c1710e320132a257321R3)